### PR TITLE
Implement M-Pesa STK Push for deposits (Daraja 3.0)

### DIFF
--- a/migrations/000006_create_mpesa_transactions_table.down.sql
+++ b/migrations/000006_create_mpesa_transactions_table.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS mpesa_transactions;
+DROP TYPE IF EXISTS mpesa_transaction_status;

--- a/migrations/000006_create_mpesa_transactions_table.up.sql
+++ b/migrations/000006_create_mpesa_transactions_table.up.sql
@@ -1,0 +1,23 @@
+CREATE TYPE mpesa_transaction_status AS ENUM ('pending', 'processing', 'completed', 'failed', 'cancelled');
+
+CREATE TABLE mpesa_transactions (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    transaction_id UUID REFERENCES transactions(id),
+    checkout_request_id VARCHAR(100) UNIQUE,
+    merchant_request_id VARCHAR(100),
+    amount DECIMAL(20, 2) NOT NULL CHECK (amount > 0),
+    phone VARCHAR(20) NOT NULL,
+    status mpesa_transaction_status DEFAULT 'pending',
+    mpesa_receipt VARCHAR(50),
+    result_code INT,
+    result_desc TEXT,
+    callback_payload JSONB,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX idx_mpesa_transactions_user_id ON mpesa_transactions(user_id);
+CREATE INDEX idx_mpesa_transactions_checkout_request_id ON mpesa_transactions(checkout_request_id);
+CREATE INDEX idx_mpesa_transactions_status ON mpesa_transactions(status);
+CREATE INDEX idx_mpesa_transactions_created_at ON mpesa_transactions(created_at DESC);

--- a/pkg/mpesa/daraja.go
+++ b/pkg/mpesa/daraja.go
@@ -1,0 +1,273 @@
+package mpesa
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+)
+
+type Config struct {
+	ConsumerKey    string
+	ConsumerSecret string
+	PassKey        string
+	ShortCode      string
+	CallbackURL    string
+	Sandbox        bool
+}
+
+type Client struct {
+	config      *Config
+	httpClient  *http.Client
+	baseURL     string
+	accessToken string
+	tokenExpiry time.Time
+	mu          sync.RWMutex
+}
+
+func NewClient(cfg *Config) *Client {
+	baseURL := "https://api.safaricom.co.ke"
+	if cfg.Sandbox {
+		baseURL = "https://sandbox.safaricom.co.ke"
+	}
+
+	return &Client{
+		config: cfg,
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+		baseURL: baseURL,
+	}
+}
+
+type tokenResponse struct {
+	AccessToken string `json:"access_token"`
+	ExpiresIn   string `json:"expires_in"`
+}
+
+func (c *Client) getAccessToken(ctx context.Context) (string, error) {
+	c.mu.RLock()
+	if c.accessToken != "" && time.Now().Before(c.tokenExpiry) {
+		token := c.accessToken
+		c.mu.RUnlock()
+		return token, nil
+	}
+	c.mu.RUnlock()
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.accessToken != "" && time.Now().Before(c.tokenExpiry) {
+		return c.accessToken, nil
+	}
+
+	url := fmt.Sprintf("%s/oauth/v1/generate?grant_type=client_credentials", c.baseURL)
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+
+	auth := base64.StdEncoding.EncodeToString(
+		[]byte(c.config.ConsumerKey + ":" + c.config.ConsumerSecret),
+	)
+	req.Header.Set("Authorization", "Basic "+auth)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to get access token: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("token request failed with status %d", resp.StatusCode)
+	}
+
+	var tokenResp tokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
+		return "", fmt.Errorf("failed to decode token response: %w", err)
+	}
+
+	c.accessToken = tokenResp.AccessToken
+	c.tokenExpiry = time.Now().Add(55 * time.Minute)
+
+	return c.accessToken, nil
+}
+
+type STKPushRequest struct {
+	BusinessShortCode string `json:"BusinessShortCode"`
+	Password          string `json:"Password"`
+	Timestamp         string `json:"Timestamp"`
+	TransactionType   string `json:"TransactionType"`
+	Amount            int    `json:"Amount"`
+	PartyA            string `json:"PartyA"`
+	PartyB            string `json:"PartyB"`
+	PhoneNumber       string `json:"PhoneNumber"`
+	CallBackURL       string `json:"CallBackURL"`
+	AccountReference  string `json:"AccountReference"`
+	TransactionDesc   string `json:"TransactionDesc"`
+}
+
+type STKPushResponse struct {
+	MerchantRequestID   string `json:"MerchantRequestID"`
+	CheckoutRequestID   string `json:"CheckoutRequestID"`
+	ResponseCode        string `json:"ResponseCode"`
+	ResponseDescription string `json:"ResponseDescription"`
+	CustomerMessage     string `json:"CustomerMessage"`
+}
+
+func (c *Client) STKPush(ctx context.Context, phone string, amount int, reference string) (*STKPushResponse, error) {
+	token, err := c.getAccessToken(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	timestamp := time.Now().Format("20060102150405")
+	password := base64.StdEncoding.EncodeToString(
+		[]byte(c.config.ShortCode + c.config.PassKey + timestamp),
+	)
+
+	reqBody := STKPushRequest{
+		BusinessShortCode: c.config.ShortCode,
+		Password:          password,
+		Timestamp:         timestamp,
+		TransactionType:   "CustomerPayBillOnline",
+		Amount:            amount,
+		PartyA:            phone,
+		PartyB:            c.config.ShortCode,
+		PhoneNumber:       phone,
+		CallBackURL:       c.config.CallbackURL,
+		AccountReference:  reference,
+		TransactionDesc:   "EquiShare Deposit",
+	}
+
+	jsonBody, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/mpesa/stkpush/v1/processrequest", c.baseURL)
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(jsonBody))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send STK push: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var stkResp STKPushResponse
+	if err := json.NewDecoder(resp.Body).Decode(&stkResp); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	if stkResp.ResponseCode != "0" {
+		return nil, fmt.Errorf("STK push failed: %s", stkResp.ResponseDescription)
+	}
+
+	return &stkResp, nil
+}
+
+type STKCallback struct {
+	Body struct {
+		StkCallback struct {
+			MerchantRequestID string `json:"MerchantRequestID"`
+			CheckoutRequestID string `json:"CheckoutRequestID"`
+			ResultCode        int    `json:"ResultCode"`
+			ResultDesc        string `json:"ResultDesc"`
+			CallbackMetadata  *struct {
+				Item []CallbackItem `json:"Item"`
+			} `json:"CallbackMetadata"`
+		} `json:"stkCallback"`
+	} `json:"Body"`
+}
+
+type CallbackItem struct {
+	Name  string `json:"Name"`
+	Value any    `json:"Value"`
+}
+
+type CallbackData struct {
+	MerchantRequestID string
+	CheckoutRequestID string
+	ResultCode        int
+	ResultDesc        string
+	Amount            float64
+	MpesaReceiptNo    string
+	TransactionDate   string
+	PhoneNumber       string
+}
+
+func ParseCallback(callback *STKCallback) *CallbackData {
+	data := &CallbackData{
+		MerchantRequestID: callback.Body.StkCallback.MerchantRequestID,
+		CheckoutRequestID: callback.Body.StkCallback.CheckoutRequestID,
+		ResultCode:        callback.Body.StkCallback.ResultCode,
+		ResultDesc:        callback.Body.StkCallback.ResultDesc,
+	}
+
+	if callback.Body.StkCallback.CallbackMetadata != nil {
+		for _, item := range callback.Body.StkCallback.CallbackMetadata.Item {
+			switch item.Name {
+			case "Amount":
+				if v, ok := item.Value.(float64); ok {
+					data.Amount = v
+				}
+			case "MpesaReceiptNumber":
+				if v, ok := item.Value.(string); ok {
+					data.MpesaReceiptNo = v
+				}
+			case "TransactionDate":
+				if v, ok := item.Value.(float64); ok {
+					data.TransactionDate = fmt.Sprintf("%.0f", v)
+				}
+			case "PhoneNumber":
+				if v, ok := item.Value.(float64); ok {
+					data.PhoneNumber = fmt.Sprintf("%.0f", v)
+				}
+			}
+		}
+	}
+
+	return data
+}
+
+type MockClient struct {
+	Requests []MockSTKRequest
+}
+
+type MockSTKRequest struct {
+	Phone     string
+	Amount    int
+	Reference string
+}
+
+func NewMockClient() *MockClient {
+	return &MockClient{
+		Requests: make([]MockSTKRequest, 0),
+	}
+}
+
+func (c *MockClient) STKPush(ctx context.Context, phone string, amount int, reference string) (*STKPushResponse, error) {
+	c.Requests = append(c.Requests, MockSTKRequest{
+		Phone:     phone,
+		Amount:    amount,
+		Reference: reference,
+	})
+
+	return &STKPushResponse{
+		MerchantRequestID:   fmt.Sprintf("mock-merchant-%d", time.Now().UnixNano()),
+		CheckoutRequestID:   fmt.Sprintf("mock-checkout-%d", time.Now().UnixNano()),
+		ResponseCode:        "0",
+		ResponseDescription: "Success. Request accepted for processing",
+		CustomerMessage:     "Success. Request accepted for processing",
+	}, nil
+}

--- a/services/payment-service/internal/handler/handler.go
+++ b/services/payment-service/internal/handler/handler.go
@@ -1,0 +1,254 @@
+package handler
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gofiber/fiber/v2"
+
+	apperrors "github.com/Rohianon/equishare-global-trading/pkg/errors"
+	"github.com/Rohianon/equishare-global-trading/pkg/events"
+	"github.com/Rohianon/equishare-global-trading/pkg/logger"
+	"github.com/Rohianon/equishare-global-trading/pkg/mpesa"
+	"github.com/Rohianon/equishare-global-trading/services/payment-service/internal/repository"
+	"github.com/Rohianon/equishare-global-trading/services/payment-service/internal/types"
+)
+
+type MpesaClient interface {
+	STKPush(ctx context.Context, phone string, amount int, reference string) (*mpesa.STKPushResponse, error)
+}
+
+type SMSClient interface {
+	Send(to, message string) error
+}
+
+type Handler struct {
+	userRepo   *repository.UserRepository
+	walletRepo *repository.WalletRepository
+	mpesaRepo  *repository.MpesaRepository
+	mpesa      MpesaClient
+	sms        SMSClient
+	publisher  events.Publisher
+}
+
+func New(
+	userRepo *repository.UserRepository,
+	walletRepo *repository.WalletRepository,
+	mpesaRepo *repository.MpesaRepository,
+	mpesa MpesaClient,
+	sms SMSClient,
+	publisher events.Publisher,
+) *Handler {
+	return &Handler{
+		userRepo:   userRepo,
+		walletRepo: walletRepo,
+		mpesaRepo:  mpesaRepo,
+		mpesa:      mpesa,
+		sms:        sms,
+		publisher:  publisher,
+	}
+}
+
+func (h *Handler) Deposit(c *fiber.Ctx) error {
+	userID := c.Locals("user_id").(string)
+
+	var req types.DepositRequest
+	if err := c.BodyParser(&req); err != nil {
+		return apperrors.ErrValidation.WithDetails("Invalid request body")
+	}
+
+	if req.Amount < 10 {
+		return apperrors.ErrValidation.WithDetails("Minimum deposit is KES 10")
+	}
+	if req.Amount > 150000 {
+		return apperrors.ErrValidation.WithDetails("Maximum deposit is KES 150,000")
+	}
+
+	ctx := c.Context()
+
+	user, err := h.userRepo.GetByID(ctx, userID)
+	if err != nil {
+		logger.Error().Err(err).Str("user_id", userID).Msg("Failed to get user")
+		return apperrors.ErrInternal
+	}
+
+	if !user.IsActive {
+		return apperrors.ErrForbidden.WithDetails("Account is deactivated")
+	}
+
+	wallet, err := h.walletRepo.GetByUserAndCurrency(ctx, userID, "KES")
+	if err != nil {
+		logger.Error().Err(err).Str("user_id", userID).Msg("Failed to get wallet")
+		return apperrors.ErrInternal
+	}
+
+	reference := fmt.Sprintf("EQS-%s", userID[:8])
+	stkResp, err := h.mpesa.STKPush(ctx, user.Phone, req.Amount, reference)
+	if err != nil {
+		logger.Error().Err(err).Str("user_id", userID).Msg("Failed to initiate STK push")
+		return apperrors.ErrServiceUnavailable.WithDetails("Failed to initiate M-Pesa payment")
+	}
+
+	_, err = h.mpesaRepo.Create(ctx, userID, stkResp.CheckoutRequestID, stkResp.MerchantRequestID, user.Phone, float64(req.Amount))
+	if err != nil {
+		logger.Error().Err(err).Msg("Failed to save mpesa transaction")
+	}
+
+	if h.publisher != nil {
+		h.publisher.Publish(ctx, events.TopicPaymentInitiated, &events.Event{
+			Type:   "payment.initiated",
+			Source: "payment-service",
+			Data: map[string]any{
+				"user_id":             userID,
+				"wallet_id":           wallet.ID,
+				"amount":              req.Amount,
+				"currency":            "KES",
+				"checkout_request_id": stkResp.CheckoutRequestID,
+			},
+		})
+	}
+
+	logger.Info().
+		Str("user_id", userID).
+		Int("amount", req.Amount).
+		Str("checkout_request_id", stkResp.CheckoutRequestID).
+		Msg("STK push initiated")
+
+	return c.Status(fiber.StatusOK).JSON(types.DepositResponse{
+		CheckoutRequestID: stkResp.CheckoutRequestID,
+		Message:           "STK Push sent to your phone. Enter your M-Pesa PIN to complete.",
+		Amount:            req.Amount,
+		Currency:          "KES",
+	})
+}
+
+func (h *Handler) STKCallback(c *fiber.Ctx) error {
+	var callback mpesa.STKCallback
+	if err := c.BodyParser(&callback); err != nil {
+		logger.Error().Err(err).Msg("Failed to parse STK callback")
+		return c.Status(fiber.StatusOK).JSON(types.WebhookResponse{
+			ResultCode: 0,
+			ResultDesc: "Accepted",
+		})
+	}
+
+	data := mpesa.ParseCallback(&callback)
+	ctx := c.Context()
+
+	logger.Info().
+		Str("checkout_request_id", data.CheckoutRequestID).
+		Int("result_code", data.ResultCode).
+		Str("result_desc", data.ResultDesc).
+		Msg("Received STK callback")
+
+	mpesaTx, err := h.mpesaRepo.GetByCheckoutRequestID(ctx, data.CheckoutRequestID)
+	if err != nil {
+		logger.Error().Err(err).Str("checkout_request_id", data.CheckoutRequestID).Msg("Mpesa transaction not found")
+		return c.Status(fiber.StatusOK).JSON(types.WebhookResponse{
+			ResultCode: 0,
+			ResultDesc: "Accepted",
+		})
+	}
+
+	if mpesaTx.Status != "pending" {
+		logger.Warn().Str("checkout_request_id", data.CheckoutRequestID).Msg("Duplicate callback ignored")
+		return c.Status(fiber.StatusOK).JSON(types.WebhookResponse{
+			ResultCode: 0,
+			ResultDesc: "Accepted",
+		})
+	}
+
+	err = h.mpesaRepo.UpdateCallback(ctx, data.CheckoutRequestID, data.ResultCode, data.ResultDesc, data.MpesaReceiptNo, callback)
+	if err != nil {
+		logger.Error().Err(err).Msg("Failed to update mpesa transaction")
+	}
+
+	if data.ResultCode == 0 {
+		wallet, err := h.walletRepo.GetByUserAndCurrency(ctx, mpesaTx.UserID, "KES")
+		if err != nil {
+			logger.Error().Err(err).Msg("Failed to get wallet")
+		} else {
+			err = h.walletRepo.Credit(ctx, wallet.ID, data.Amount)
+			if err != nil {
+				logger.Error().Err(err).Msg("Failed to credit wallet")
+			} else {
+				description := fmt.Sprintf("M-Pesa deposit - %s", data.MpesaReceiptNo)
+				tx, err := h.walletRepo.CreateTransaction(ctx, mpesaTx.UserID, wallet.ID, "deposit", "mpesa", data.MpesaReceiptNo, data.Amount, description)
+				if err != nil {
+					logger.Error().Err(err).Msg("Failed to create transaction record")
+				} else {
+					h.mpesaRepo.LinkTransaction(ctx, mpesaTx.ID, tx.ID)
+				}
+
+				if h.publisher != nil {
+					h.publisher.Publish(ctx, events.TopicPaymentCompleted, &events.Event{
+						Type:   "payment.completed",
+						Source: "payment-service",
+						Data: map[string]any{
+							"user_id":        mpesaTx.UserID,
+							"wallet_id":      wallet.ID,
+							"amount":         data.Amount,
+							"currency":       "KES",
+							"mpesa_receipt":  data.MpesaReceiptNo,
+							"transaction_id": tx.ID,
+						},
+					})
+				}
+
+				user, _ := h.userRepo.GetByID(ctx, mpesaTx.UserID)
+				if user != nil && h.sms != nil {
+					msg := fmt.Sprintf("Your EquiShare wallet has been credited with KES %.2f. Receipt: %s. New balance: KES %.2f",
+						data.Amount, data.MpesaReceiptNo, wallet.Balance+data.Amount)
+					h.sms.Send(user.Phone, msg)
+				}
+
+				logger.Info().
+					Str("user_id", mpesaTx.UserID).
+					Float64("amount", data.Amount).
+					Str("mpesa_receipt", data.MpesaReceiptNo).
+					Msg("Deposit completed successfully")
+			}
+		}
+	} else {
+		if h.publisher != nil {
+			h.publisher.Publish(ctx, events.TopicPaymentFailed, &events.Event{
+				Type:   "payment.failed",
+				Source: "payment-service",
+				Data: map[string]any{
+					"user_id":             mpesaTx.UserID,
+					"amount":              mpesaTx.Amount,
+					"result_code":         data.ResultCode,
+					"result_desc":         data.ResultDesc,
+					"checkout_request_id": data.CheckoutRequestID,
+				},
+			})
+		}
+
+		logger.Info().
+			Str("user_id", mpesaTx.UserID).
+			Int("result_code", data.ResultCode).
+			Str("result_desc", data.ResultDesc).
+			Msg("Deposit failed")
+	}
+
+	return c.Status(fiber.StatusOK).JSON(types.WebhookResponse{
+		ResultCode: 0,
+		ResultDesc: "Accepted",
+	})
+}
+
+func (h *Handler) GetWalletBalance(c *fiber.Ctx) error {
+	userID := c.Locals("user_id").(string)
+	ctx := c.Context()
+
+	wallet, err := h.walletRepo.GetByUserAndCurrency(ctx, userID, "KES")
+	if err != nil {
+		return apperrors.ErrNotFound.WithDetails("Wallet not found")
+	}
+
+	return c.JSON(fiber.Map{
+		"currency":       wallet.Currency,
+		"balance":        wallet.Balance,
+		"locked_balance": wallet.LockedBalance,
+	})
+}

--- a/services/payment-service/internal/repository/mpesa.go
+++ b/services/payment-service/internal/repository/mpesa.go
@@ -1,0 +1,94 @@
+package repository
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Rohianon/equishare-global-trading/services/payment-service/internal/types"
+)
+
+type MpesaRepository struct {
+	db *pgxpool.Pool
+}
+
+func NewMpesaRepository(db *pgxpool.Pool) *MpesaRepository {
+	return &MpesaRepository{db: db}
+}
+
+func (r *MpesaRepository) Create(ctx context.Context, userID, checkoutRequestID, merchantRequestID, phone string, amount float64) (*types.MpesaTransaction, error) {
+	var tx types.MpesaTransaction
+
+	err := r.db.QueryRow(ctx, `
+		INSERT INTO mpesa_transactions (user_id, checkout_request_id, merchant_request_id, phone, amount, status)
+		VALUES ($1, $2, $3, $4, $5, 'pending')
+		RETURNING id, user_id, transaction_id, checkout_request_id, merchant_request_id,
+		          amount, phone, status, mpesa_receipt, result_code, result_desc,
+		          callback_payload, created_at, updated_at
+	`, userID, checkoutRequestID, merchantRequestID, phone, amount).Scan(
+		&tx.ID, &tx.UserID, &tx.TransactionID, &tx.CheckoutRequestID, &tx.MerchantRequestID,
+		&tx.Amount, &tx.Phone, &tx.Status, &tx.MpesaReceipt, &tx.ResultCode, &tx.ResultDesc,
+		&tx.CallbackPayload, &tx.CreatedAt, &tx.UpdatedAt,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create mpesa transaction: %w", err)
+	}
+
+	return &tx, nil
+}
+
+func (r *MpesaRepository) GetByCheckoutRequestID(ctx context.Context, checkoutRequestID string) (*types.MpesaTransaction, error) {
+	var tx types.MpesaTransaction
+
+	err := r.db.QueryRow(ctx, `
+		SELECT id, user_id, transaction_id, checkout_request_id, merchant_request_id,
+		       amount, phone, status, mpesa_receipt, result_code, result_desc,
+		       callback_payload, created_at, updated_at
+		FROM mpesa_transactions WHERE checkout_request_id = $1
+	`, checkoutRequestID).Scan(
+		&tx.ID, &tx.UserID, &tx.TransactionID, &tx.CheckoutRequestID, &tx.MerchantRequestID,
+		&tx.Amount, &tx.Phone, &tx.Status, &tx.MpesaReceipt, &tx.ResultCode, &tx.ResultDesc,
+		&tx.CallbackPayload, &tx.CreatedAt, &tx.UpdatedAt,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get mpesa transaction: %w", err)
+	}
+
+	return &tx, nil
+}
+
+func (r *MpesaRepository) UpdateCallback(ctx context.Context, checkoutRequestID string, resultCode int, resultDesc, mpesaReceipt string, payload any) error {
+	payloadJSON, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("failed to marshal callback payload: %w", err)
+	}
+
+	status := "failed"
+	if resultCode == 0 {
+		status = "completed"
+	}
+
+	_, err = r.db.Exec(ctx, `
+		UPDATE mpesa_transactions
+		SET status = $1, result_code = $2, result_desc = $3, mpesa_receipt = $4,
+		    callback_payload = $5, updated_at = NOW()
+		WHERE checkout_request_id = $6
+	`, status, resultCode, resultDesc, mpesaReceipt, payloadJSON, checkoutRequestID)
+	if err != nil {
+		return fmt.Errorf("failed to update mpesa transaction: %w", err)
+	}
+
+	return nil
+}
+
+func (r *MpesaRepository) LinkTransaction(ctx context.Context, mpesaID, transactionID string) error {
+	_, err := r.db.Exec(ctx, `
+		UPDATE mpesa_transactions SET transaction_id = $1 WHERE id = $2
+	`, transactionID, mpesaID)
+	if err != nil {
+		return fmt.Errorf("failed to link transaction: %w", err)
+	}
+	return nil
+}

--- a/services/payment-service/internal/repository/user.go
+++ b/services/payment-service/internal/repository/user.go
@@ -1,0 +1,35 @@
+package repository
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type User struct {
+	ID       string
+	Phone    string
+	IsActive bool
+}
+
+type UserRepository struct {
+	db *pgxpool.Pool
+}
+
+func NewUserRepository(db *pgxpool.Pool) *UserRepository {
+	return &UserRepository{db: db}
+}
+
+func (r *UserRepository) GetByID(ctx context.Context, id string) (*User, error) {
+	var user User
+
+	err := r.db.QueryRow(ctx, `
+		SELECT id, phone, is_active FROM users WHERE id = $1
+	`, id).Scan(&user.ID, &user.Phone, &user.IsActive)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get user: %w", err)
+	}
+
+	return &user, nil
+}

--- a/services/payment-service/internal/repository/wallet.go
+++ b/services/payment-service/internal/repository/wallet.go
@@ -1,0 +1,68 @@
+package repository
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Rohianon/equishare-global-trading/services/payment-service/internal/types"
+)
+
+type WalletRepository struct {
+	db *pgxpool.Pool
+}
+
+func NewWalletRepository(db *pgxpool.Pool) *WalletRepository {
+	return &WalletRepository{db: db}
+}
+
+func (r *WalletRepository) GetByUserAndCurrency(ctx context.Context, userID, currency string) (*types.Wallet, error) {
+	var wallet types.Wallet
+
+	err := r.db.QueryRow(ctx, `
+		SELECT id, user_id, currency, balance, locked_balance, created_at, updated_at
+		FROM wallets WHERE user_id = $1 AND currency = $2
+	`, userID, currency).Scan(
+		&wallet.ID, &wallet.UserID, &wallet.Currency,
+		&wallet.Balance, &wallet.LockedBalance,
+		&wallet.CreatedAt, &wallet.UpdatedAt,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get wallet: %w", err)
+	}
+
+	return &wallet, nil
+}
+
+func (r *WalletRepository) Credit(ctx context.Context, walletID string, amount float64) error {
+	_, err := r.db.Exec(ctx, `
+		UPDATE wallets
+		SET balance = balance + $1, updated_at = NOW()
+		WHERE id = $2
+	`, amount, walletID)
+	if err != nil {
+		return fmt.Errorf("failed to credit wallet: %w", err)
+	}
+	return nil
+}
+
+func (r *WalletRepository) CreateTransaction(ctx context.Context, userID, walletID, txType, provider, providerRef string, amount float64, description string) (*types.Transaction, error) {
+	var tx types.Transaction
+
+	err := r.db.QueryRow(ctx, `
+		INSERT INTO transactions (user_id, wallet_id, type, status, amount, currency, provider, provider_ref, description, completed_at)
+		VALUES ($1, $2, $3, 'completed', $4, 'KES', $5, $6, $7, NOW())
+		RETURNING id, user_id, wallet_id, type, status, amount, fee, currency, provider,
+		          provider_ref, description, completed_at, created_at, updated_at
+	`, userID, walletID, txType, amount, provider, providerRef, description).Scan(
+		&tx.ID, &tx.UserID, &tx.WalletID, &tx.Type, &tx.Status, &tx.Amount, &tx.Fee,
+		&tx.Currency, &tx.Provider, &tx.ProviderRef, &tx.Description, &tx.CompletedAt,
+		&tx.CreatedAt, &tx.UpdatedAt,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create transaction: %w", err)
+	}
+
+	return &tx, nil
+}

--- a/services/payment-service/internal/types/types.go
+++ b/services/payment-service/internal/types/types.go
@@ -1,0 +1,63 @@
+package types
+
+import "time"
+
+type DepositRequest struct {
+	Amount int `json:"amount" validate:"required,min=10,max=150000"`
+}
+
+type DepositResponse struct {
+	CheckoutRequestID string `json:"checkout_request_id"`
+	Message           string `json:"message"`
+	Amount            int    `json:"amount"`
+	Currency          string `json:"currency"`
+}
+
+type MpesaTransaction struct {
+	ID                string
+	UserID            string
+	TransactionID     *string
+	CheckoutRequestID string
+	MerchantRequestID string
+	Amount            float64
+	Phone             string
+	Status            string
+	MpesaReceipt      *string
+	ResultCode        *int
+	ResultDesc        *string
+	CallbackPayload   []byte
+	CreatedAt         time.Time
+	UpdatedAt         time.Time
+}
+
+type Wallet struct {
+	ID            string
+	UserID        string
+	Currency      string
+	Balance       float64
+	LockedBalance float64
+	CreatedAt     time.Time
+	UpdatedAt     time.Time
+}
+
+type Transaction struct {
+	ID          string
+	UserID      string
+	WalletID    string
+	Type        string
+	Status      string
+	Amount      float64
+	Fee         float64
+	Currency    string
+	Provider    string
+	ProviderRef *string
+	Description *string
+	CompletedAt *time.Time
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+}
+
+type WebhookResponse struct {
+	ResultCode int    `json:"ResultCode"`
+	ResultDesc string `json:"ResultDesc"`
+}

--- a/services/payment-service/main.go
+++ b/services/payment-service/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"net"
 	"os"
@@ -10,27 +11,122 @@ import (
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/middleware/recover"
 
+	"github.com/Rohianon/equishare-global-trading/pkg/config"
+	"github.com/Rohianon/equishare-global-trading/pkg/database"
+	"github.com/Rohianon/equishare-global-trading/pkg/events"
 	"github.com/Rohianon/equishare-global-trading/pkg/logger"
 	"github.com/Rohianon/equishare-global-trading/pkg/middleware"
+	"github.com/Rohianon/equishare-global-trading/pkg/mpesa"
+	"github.com/Rohianon/equishare-global-trading/pkg/sms"
+	"github.com/Rohianon/equishare-global-trading/services/payment-service/internal/handler"
+	"github.com/Rohianon/equishare-global-trading/services/payment-service/internal/repository"
 )
 
 func main() {
 	logger.Init("payment-service", "info", true)
 	logger.Info().Msg("Starting Payment Service")
 
-	app := fiber.New(fiber.Config{AppName: "EquiShare Payment Service"})
+	cfg, err := config.Load("config")
+	if err != nil {
+		logger.Warn().Err(err).Msg("Failed to load config, using defaults")
+	}
+
+	ctx := context.Background()
+
+	dbCfg := &database.Config{
+		Host:     getEnvOrDefault("DB_HOST", cfg.Database.Host),
+		Port:     cfg.Database.Port,
+		User:     getEnvOrDefault("DB_USER", cfg.Database.User),
+		Password: getEnvOrDefault("DB_PASSWORD", cfg.Database.Password),
+		Database: getEnvOrDefault("DB_NAME", cfg.Database.Database),
+		SSLMode:  cfg.Database.SSLMode,
+	}
+	if dbCfg.Port == 0 {
+		dbCfg.Port = 5432
+	}
+	if dbCfg.SSLMode == "" {
+		dbCfg.SSLMode = "disable"
+	}
+
+	db, err := database.NewPool(ctx, dbCfg)
+	if err != nil {
+		logger.Fatal().Err(err).Msg("Failed to connect to database")
+	}
+	defer db.Close()
+	logger.Info().Msg("Connected to database")
+
+	var mpesaClient handler.MpesaClient
+	if os.Getenv("MPESA_SANDBOX") == "true" || os.Getenv("MPESA_CONSUMER_KEY") == "" {
+		logger.Warn().Msg("Using mock M-Pesa client")
+		mpesaClient = mpesa.NewMockClient()
+	} else {
+		mpesaClient = mpesa.NewClient(&mpesa.Config{
+			ConsumerKey:    os.Getenv("MPESA_CONSUMER_KEY"),
+			ConsumerSecret: os.Getenv("MPESA_CONSUMER_SECRET"),
+			PassKey:        os.Getenv("MPESA_PASSKEY"),
+			ShortCode:      os.Getenv("MPESA_SHORTCODE"),
+			CallbackURL:    os.Getenv("MPESA_CALLBACK_URL"),
+			Sandbox:        os.Getenv("MPESA_SANDBOX") == "true",
+		})
+	}
+
+	var smsClient handler.SMSClient
+	if os.Getenv("SMS_SANDBOX") == "true" || os.Getenv("AT_API_KEY") == "" {
+		logger.Warn().Msg("Using mock SMS client")
+		smsClient = sms.NewMockClient()
+	} else {
+		smsClient = sms.NewClient(&sms.Config{
+			APIKey:   os.Getenv("AT_API_KEY"),
+			Username: os.Getenv("AT_USERNAME"),
+			Sender:   os.Getenv("AT_SENDER"),
+			Sandbox:  os.Getenv("AT_SANDBOX") == "true",
+		})
+	}
+
+	var publisher events.Publisher
+	if brokers := cfg.Kafka.Brokers; len(brokers) > 0 && brokers[0] != "" {
+		publisher = events.NewKafkaPublisher(brokers)
+		defer publisher.Close()
+		logger.Info().Msg("Connected to Kafka")
+	} else {
+		logger.Warn().Msg("Kafka not configured, events will not be published")
+	}
+
+	userRepo := repository.NewUserRepository(db)
+	walletRepo := repository.NewWalletRepository(db)
+	mpesaRepo := repository.NewMpesaRepository(db)
+
+	h := handler.New(userRepo, walletRepo, mpesaRepo, mpesaClient, smsClient, publisher)
+
+	jwtSecret := getEnvOrDefault("JWT_SECRET", "dev-secret-change-in-production")
+
+	app := fiber.New(fiber.Config{
+		AppName:      "EquiShare Payment Service",
+		ErrorHandler: errorHandler,
+	})
 	app.Use(recover.New())
 	app.Use(middleware.RequestID())
+	app.Use(middleware.Logger())
+	app.Use(middleware.SecurityHeaders())
 
 	app.Get("/health", func(c *fiber.Ctx) error {
 		return c.JSON(fiber.Map{"status": "healthy", "service": "payment-service"})
 	})
 
+	app.Post("/webhooks/mpesa/stk-callback", h.STKCallback)
+
+	api := app.Group("/api/v1")
+	wallet := api.Group("/wallet", middleware.Auth(jwtSecret))
+	wallet.Post("/deposit", h.Deposit)
+	wallet.Get("/balance", h.GetWalletBalance)
+
+	port := getEnvOrDefault("PORT", "8004")
 	go func() {
-		if err := app.Listen(":8004"); err != nil && !errors.Is(err, net.ErrClosed) {
+		if err := app.Listen(":" + port); err != nil && !errors.Is(err, net.ErrClosed) {
 			logger.Fatal().Err(err).Msg("Failed to start server")
 		}
 	}()
+	logger.Info().Str("port", port).Msg("Payment Service started")
 
 	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
@@ -40,4 +136,26 @@ func main() {
 	if err := app.Shutdown(); err != nil {
 		logger.Error().Err(err).Msg("Error during shutdown")
 	}
+}
+
+func getEnvOrDefault(key, defaultVal string) string {
+	if val := os.Getenv(key); val != "" {
+		return val
+	}
+	return defaultVal
+}
+
+func errorHandler(c *fiber.Ctx, err error) error {
+	code := fiber.StatusInternalServerError
+	message := "Internal Server Error"
+
+	var e *fiber.Error
+	if errors.As(err, &e) {
+		code = e.Code
+		message = e.Message
+	}
+
+	return c.Status(code).JSON(fiber.Map{
+		"error": message,
+	})
 }


### PR DESCRIPTION
## Summary

Integrate Safaricom Daraja 3.0 API for M-Pesa deposits via STK Push.

## API Endpoints

| Method | Endpoint | Auth | Description |
|--------|----------|------|-------------|
| POST | `/api/v1/wallet/deposit` | JWT | Initiate STK Push |
| GET | `/api/v1/wallet/balance` | JWT | Get wallet balance |
| POST | `/webhooks/mpesa/stk-callback` | None | M-Pesa callback |

## Deposit Flow

```
1. User calls POST /wallet/deposit with amount
2. Server initiates STK Push to user's phone
3. User enters M-Pesa PIN on phone
4. M-Pesa sends callback to /webhooks/mpesa/stk-callback
5. Server credits wallet and creates transaction
6. User receives SMS confirmation
```

## New Package: pkg/mpesa

- Daraja 3.0 client with OAuth token caching (55 min)
- STK Push request builder with password generation
- Callback parser for metadata extraction
- Mock client for development

## Database

- Migration 000006: `mpesa_transactions` table

## Security

- Deposit limits: KES 10 - 150,000
- Idempotent callbacks (status check prevents double credits)
- JWT auth required for deposit endpoint
- Webhook endpoint validates callback structure

## Test plan

- [x] Build passes (`make build`)
- [x] Mock M-Pesa client for dev environment

Closes #19