### PR TITLE
Implement Alpaca Trading API integration for paper trading

### DIFF
--- a/pkg/alpaca/alpaca_test.go
+++ b/pkg/alpaca/alpaca_test.go
@@ -1,0 +1,308 @@
+package alpaca
+
+import (
+	"context"
+	"testing"
+)
+
+func TestNewClient(t *testing.T) {
+	tests := []struct {
+		name    string
+		paper   bool
+		wantURL string
+	}{
+		{
+			name:    "production client",
+			paper:   false,
+			wantURL: "https://api.alpaca.markets",
+		},
+		{
+			name:    "paper trading client",
+			paper:   true,
+			wantURL: "https://paper-api.alpaca.markets",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := NewClient(&Config{
+				APIKey:    "test-key",
+				SecretKey: "test-secret",
+				Paper:     tt.paper,
+			})
+
+			if client.baseURL != tt.wantURL {
+				t.Errorf("baseURL = %v, want %v", client.baseURL, tt.wantURL)
+			}
+		})
+	}
+}
+
+func TestMockClient_CreateOrder(t *testing.T) {
+	ctx := context.Background()
+	client := NewMockClient()
+
+	order, err := client.CreateOrder(ctx, &CreateOrderRequest{
+		Symbol:      "AAPL",
+		Qty:         "10",
+		Side:        Buy,
+		Type:        Market,
+		TimeInForce: Day,
+	})
+
+	if err != nil {
+		t.Fatalf("CreateOrder failed: %v", err)
+	}
+
+	if order.Symbol != "AAPL" {
+		t.Errorf("order.Symbol = %v, want AAPL", order.Symbol)
+	}
+
+	if order.Status != OrderStatusFilled {
+		t.Errorf("order.Status = %v, want %v", order.Status, OrderStatusFilled)
+	}
+
+	if order.Side != Buy {
+		t.Errorf("order.Side = %v, want %v", order.Side, Buy)
+	}
+}
+
+func TestMockClient_GetOrder(t *testing.T) {
+	ctx := context.Background()
+	client := NewMockClient()
+
+	created, _ := client.CreateOrder(ctx, &CreateOrderRequest{
+		Symbol:      "GOOGL",
+		Qty:         "5",
+		Side:        Buy,
+		Type:        Market,
+		TimeInForce: Day,
+	})
+
+	retrieved, err := client.GetOrder(ctx, created.ID)
+	if err != nil {
+		t.Fatalf("GetOrder failed: %v", err)
+	}
+
+	if retrieved.ID != created.ID {
+		t.Errorf("retrieved.ID = %v, want %v", retrieved.ID, created.ID)
+	}
+
+	// Test order not found
+	_, err = client.GetOrder(ctx, "non-existent")
+	if err == nil {
+		t.Error("expected error for non-existent order")
+	}
+}
+
+func TestMockClient_ListPositions(t *testing.T) {
+	ctx := context.Background()
+	client := NewMockClient()
+
+	// Initially no positions
+	positions, err := client.ListPositions(ctx)
+	if err != nil {
+		t.Fatalf("ListPositions failed: %v", err)
+	}
+	if len(positions) != 0 {
+		t.Errorf("expected 0 positions, got %d", len(positions))
+	}
+
+	// Create an order to generate a position
+	_, _ = client.CreateOrder(ctx, &CreateOrderRequest{
+		Symbol:      "MSFT",
+		Qty:         "10",
+		Side:        Buy,
+		Type:        Market,
+		TimeInForce: Day,
+	})
+
+	positions, err = client.ListPositions(ctx)
+	if err != nil {
+		t.Fatalf("ListPositions failed: %v", err)
+	}
+	if len(positions) != 1 {
+		t.Errorf("expected 1 position, got %d", len(positions))
+	}
+}
+
+func TestMockClient_CancelOrder(t *testing.T) {
+	ctx := context.Background()
+	client := NewMockClient()
+
+	// Create a limit order (won't be filled immediately)
+	order, _ := client.CreateOrder(ctx, &CreateOrderRequest{
+		Symbol:      "AMZN",
+		Qty:         "1",
+		Side:        Buy,
+		Type:        Limit,
+		LimitPrice:  "100.00",
+		TimeInForce: GTC,
+	})
+
+	err := client.CancelOrder(ctx, order.ID)
+	if err != nil {
+		t.Fatalf("CancelOrder failed: %v", err)
+	}
+
+	canceled, _ := client.GetOrder(ctx, order.ID)
+	if canceled.Status != OrderStatusCanceled {
+		t.Errorf("order.Status = %v, want %v", canceled.Status, OrderStatusCanceled)
+	}
+}
+
+func TestMockClient_GetAccount(t *testing.T) {
+	ctx := context.Background()
+	client := NewMockClient()
+
+	account, err := client.GetAccount(ctx)
+	if err != nil {
+		t.Fatalf("GetAccount failed: %v", err)
+	}
+
+	if account.Status != "ACTIVE" {
+		t.Errorf("account.Status = %v, want ACTIVE", account.Status)
+	}
+
+	if account.Currency != "USD" {
+		t.Errorf("account.Currency = %v, want USD", account.Currency)
+	}
+}
+
+func TestMockClient_GetAsset(t *testing.T) {
+	ctx := context.Background()
+	client := NewMockClient()
+
+	asset, err := client.GetAsset(ctx, "TSLA")
+	if err != nil {
+		t.Fatalf("GetAsset failed: %v", err)
+	}
+
+	if asset.Symbol != "TSLA" {
+		t.Errorf("asset.Symbol = %v, want TSLA", asset.Symbol)
+	}
+
+	if !asset.Tradable {
+		t.Error("expected asset to be tradable")
+	}
+
+	if !asset.Fractionable {
+		t.Error("expected asset to be fractionable")
+	}
+}
+
+func TestMockClient_GetQuote(t *testing.T) {
+	ctx := context.Background()
+	client := NewMockClient()
+
+	quote, err := client.GetQuote(ctx, "AAPL")
+	if err != nil {
+		t.Fatalf("GetQuote failed: %v", err)
+	}
+
+	if quote.Symbol != "AAPL" {
+		t.Errorf("quote.Symbol = %v, want AAPL", quote.Symbol)
+	}
+
+	if quote.BidPrice <= 0 {
+		t.Error("expected positive bid price")
+	}
+
+	if quote.AskPrice <= 0 {
+		t.Error("expected positive ask price")
+	}
+}
+
+func TestMockClient_ClosePosition(t *testing.T) {
+	ctx := context.Background()
+	client := NewMockClient()
+
+	// Add a position
+	client.AddMockPosition("NVDA", "50", "450.00")
+
+	// Close the position
+	order, err := client.ClosePosition(ctx, "NVDA", "")
+	if err != nil {
+		t.Fatalf("ClosePosition failed: %v", err)
+	}
+
+	if order.Side != Sell {
+		t.Errorf("order.Side = %v, want %v", order.Side, Sell)
+	}
+
+	// Position should be gone
+	_, err = client.GetPosition(ctx, "NVDA")
+	if err == nil {
+		t.Error("expected position to be closed")
+	}
+}
+
+func TestMockClient_ListAssets(t *testing.T) {
+	ctx := context.Background()
+	client := NewMockClient()
+
+	assets, err := client.ListAssets(ctx, nil)
+	if err != nil {
+		t.Fatalf("ListAssets failed: %v", err)
+	}
+
+	if len(assets) == 0 {
+		t.Error("expected some assets")
+	}
+
+	// Check that we have expected assets
+	symbols := make(map[string]bool)
+	for _, a := range assets {
+		symbols[a.Symbol] = true
+	}
+
+	expected := []string{"AAPL", "GOOGL", "MSFT", "AMZN", "TSLA"}
+	for _, s := range expected {
+		if !symbols[s] {
+			t.Errorf("expected asset %s not found", s)
+		}
+	}
+}
+
+func TestOrderStatus_Values(t *testing.T) {
+	statuses := []OrderStatus{
+		OrderStatusNew,
+		OrderStatusFilled,
+		OrderStatusCanceled,
+		OrderStatusPartiallyFilled,
+		OrderStatusRejected,
+	}
+
+	for _, s := range statuses {
+		if s == "" {
+			t.Error("order status should not be empty")
+		}
+	}
+}
+
+func TestOrderSide_Values(t *testing.T) {
+	if Buy != "buy" {
+		t.Errorf("Buy = %v, want buy", Buy)
+	}
+	if Sell != "sell" {
+		t.Errorf("Sell = %v, want sell", Sell)
+	}
+}
+
+func TestOrderType_Values(t *testing.T) {
+	if Market != "market" {
+		t.Errorf("Market = %v, want market", Market)
+	}
+	if Limit != "limit" {
+		t.Errorf("Limit = %v, want limit", Limit)
+	}
+}
+
+func TestTimeInForce_Values(t *testing.T) {
+	if Day != "day" {
+		t.Errorf("Day = %v, want day", Day)
+	}
+	if GTC != "gtc" {
+		t.Errorf("GTC = %v, want gtc", GTC)
+	}
+}

--- a/pkg/alpaca/client.go
+++ b/pkg/alpaca/client.go
@@ -1,0 +1,124 @@
+package alpaca
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// Config holds Alpaca API configuration
+type Config struct {
+	APIKey    string
+	SecretKey string
+	Paper     bool // Use paper trading environment
+}
+
+// Client is the Alpaca API client
+type Client struct {
+	config     *Config
+	httpClient *http.Client
+	baseURL    string
+	dataURL    string
+}
+
+// NewClient creates a new Alpaca API client
+func NewClient(cfg *Config) *Client {
+	baseURL := "https://api.alpaca.markets"
+	dataURL := "https://data.alpaca.markets"
+	if cfg.Paper {
+		baseURL = "https://paper-api.alpaca.markets"
+	}
+
+	return &Client{
+		config: cfg,
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+		baseURL: baseURL,
+		dataURL: dataURL,
+	}
+}
+
+// doRequest performs an authenticated HTTP request to Alpaca
+func (c *Client) doRequest(ctx context.Context, method, url string, body any) (*http.Response, error) {
+	var reqBody io.Reader
+	if body != nil {
+		jsonBody, err := json.Marshal(body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal request body: %w", err)
+		}
+		reqBody = bytes.NewReader(jsonBody)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, url, reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("APCA-API-KEY-ID", c.config.APIKey)
+	req.Header.Set("APCA-API-SECRET-KEY", c.config.SecretKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	return c.httpClient.Do(req)
+}
+
+// decodeResponse decodes a JSON response into the target
+func decodeResponse(resp *http.Response, target any) error {
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("API error (status %d): %s", resp.StatusCode, string(body))
+	}
+
+	if target != nil {
+		if err := json.NewDecoder(resp.Body).Decode(target); err != nil {
+			return fmt.Errorf("failed to decode response: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// GetAccount retrieves the trading account information
+func (c *Client) GetAccount(ctx context.Context) (*Account, error) {
+	url := fmt.Sprintf("%s/v2/account", c.baseURL)
+	resp, err := c.doRequest(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var account Account
+	if err := decodeResponse(resp, &account); err != nil {
+		return nil, err
+	}
+
+	return &account, nil
+}
+
+// Account represents an Alpaca trading account
+type Account struct {
+	ID                    string `json:"id"`
+	AccountNumber         string `json:"account_number"`
+	Status                string `json:"status"`
+	Currency              string `json:"currency"`
+	Cash                  string `json:"cash"`
+	PortfolioValue        string `json:"portfolio_value"`
+	PatternDayTrader      bool   `json:"pattern_day_trader"`
+	TradingBlocked        bool   `json:"trading_blocked"`
+	TransfersBlocked      bool   `json:"transfers_blocked"`
+	AccountBlocked        bool   `json:"account_blocked"`
+	CreatedAt             string `json:"created_at"`
+	ShortingEnabled       bool   `json:"shorting_enabled"`
+	Multiplier            string `json:"multiplier"`
+	BuyingPower           string `json:"buying_power"`
+	DaytradingBuyingPower string `json:"daytrading_buying_power"`
+	Equity                string `json:"equity"`
+	LastEquity            string `json:"last_equity"`
+	InitialMargin         string `json:"initial_margin"`
+	MaintenanceMargin     string `json:"maintenance_margin"`
+}

--- a/pkg/alpaca/interface.go
+++ b/pkg/alpaca/interface.go
@@ -1,0 +1,35 @@
+package alpaca
+
+import "context"
+
+// TradingClient defines the interface for Alpaca trading operations
+type TradingClient interface {
+	// Account
+	GetAccount(ctx context.Context) (*Account, error)
+
+	// Orders
+	CreateOrder(ctx context.Context, req *CreateOrderRequest) (*Order, error)
+	GetOrder(ctx context.Context, orderID string) (*Order, error)
+	GetOrderByClientID(ctx context.Context, clientOrderID string) (*Order, error)
+	ListOrders(ctx context.Context, params *ListOrdersParams) ([]Order, error)
+	CancelOrder(ctx context.Context, orderID string) error
+	CancelAllOrders(ctx context.Context) error
+	ReplaceOrder(ctx context.Context, orderID string, req *ReplaceOrderRequest) (*Order, error)
+
+	// Positions
+	ListPositions(ctx context.Context) ([]Position, error)
+	GetPosition(ctx context.Context, symbol string) (*Position, error)
+	ClosePosition(ctx context.Context, symbol string, qty string) (*Order, error)
+	CloseAllPositions(ctx context.Context, cancelOrders bool) ([]Order, error)
+
+	// Assets
+	GetAsset(ctx context.Context, symbol string) (*Asset, error)
+	ListAssets(ctx context.Context, params *ListAssetsParams) ([]Asset, error)
+
+	// Market Data
+	GetQuote(ctx context.Context, symbol string) (*Quote, error)
+}
+
+// Ensure Client and MockClient implement TradingClient
+var _ TradingClient = (*Client)(nil)
+var _ TradingClient = (*MockClient)(nil)

--- a/pkg/alpaca/mock.go
+++ b/pkg/alpaca/mock.go
@@ -1,0 +1,403 @@
+package alpaca
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// MockClient is a mock implementation of the Alpaca client for testing
+type MockClient struct {
+	mu        sync.RWMutex
+	orders    map[string]*Order
+	positions map[string]*Position
+	account   *Account
+}
+
+// NewMockClient creates a new mock Alpaca client
+func NewMockClient() *MockClient {
+	return &MockClient{
+		orders:    make(map[string]*Order),
+		positions: make(map[string]*Position),
+		account: &Account{
+			ID:             "mock-account-id",
+			AccountNumber:  "MOCK123456",
+			Status:         "ACTIVE",
+			Currency:       "USD",
+			Cash:           "100000.00",
+			PortfolioValue: "100000.00",
+			BuyingPower:    "100000.00",
+			Equity:         "100000.00",
+		},
+	}
+}
+
+// GetAccount returns the mock account
+func (c *MockClient) GetAccount(ctx context.Context) (*Account, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.account, nil
+}
+
+// CreateOrder creates a mock order
+func (c *MockClient) CreateOrder(ctx context.Context, req *CreateOrderRequest) (*Order, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	orderID := uuid.New().String()
+	clientOrderID := req.ClientOrderID
+	if clientOrderID == "" {
+		clientOrderID = uuid.New().String()
+	}
+
+	now := time.Now()
+	order := &Order{
+		ID:            orderID,
+		ClientOrderID: clientOrderID,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+		SubmittedAt:   now,
+		Symbol:        req.Symbol,
+		AssetClass:    "us_equity",
+		Qty:           req.Qty,
+		Notional:      req.Notional,
+		OrderType:     req.Type,
+		Side:          req.Side,
+		TimeInForce:   req.TimeInForce,
+		LimitPrice:    req.LimitPrice,
+		StopPrice:     req.StopPrice,
+		Status:        OrderStatusNew,
+		ExtendedHours: req.ExtendedHours,
+	}
+
+	// Simulate immediate fill for market orders
+	if req.Type == Market {
+		order.Status = OrderStatusFilled
+		order.FilledQty = order.Qty
+		if order.Qty == "" && order.Notional != "" {
+			order.FilledQty = "1" // Simulate fractional fill
+		}
+		order.FilledAvgPrice = "150.00" // Mock price
+		filledAt := now
+		order.FilledAt = &filledAt
+
+		// Update positions for filled orders
+		c.updatePosition(order)
+	}
+
+	c.orders[orderID] = order
+	return order, nil
+}
+
+// updatePosition updates the mock position after an order fill
+func (c *MockClient) updatePosition(order *Order) {
+	pos, exists := c.positions[order.Symbol]
+	if !exists {
+		pos = &Position{
+			AssetID:       order.AssetID,
+			Symbol:        order.Symbol,
+			Exchange:      "NASDAQ",
+			AssetClass:    "us_equity",
+			Qty:           "0",
+			AvgEntryPrice: "0",
+			Side:          "long",
+			MarketValue:   "0",
+			CostBasis:     "0",
+			CurrentPrice:  "150.00",
+		}
+		c.positions[order.Symbol] = pos
+	}
+
+	// Simple position update (not calculating exact values)
+	if order.Side == Buy {
+		pos.Qty = order.FilledQty
+		pos.AvgEntryPrice = order.FilledAvgPrice
+		pos.MarketValue = fmt.Sprintf("%.2f", 150.00) // Mock value
+	}
+}
+
+// GetOrder retrieves a mock order by ID
+func (c *MockClient) GetOrder(ctx context.Context, orderID string) (*Order, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	order, exists := c.orders[orderID]
+	if !exists {
+		return nil, fmt.Errorf("order not found: %s", orderID)
+	}
+	return order, nil
+}
+
+// GetOrderByClientID retrieves a mock order by client order ID
+func (c *MockClient) GetOrderByClientID(ctx context.Context, clientOrderID string) (*Order, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	for _, order := range c.orders {
+		if order.ClientOrderID == clientOrderID {
+			return order, nil
+		}
+	}
+	return nil, fmt.Errorf("order not found with client ID: %s", clientOrderID)
+}
+
+// ListOrders returns all mock orders
+func (c *MockClient) ListOrders(ctx context.Context, params *ListOrdersParams) ([]Order, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	orders := make([]Order, 0, len(c.orders))
+	for _, order := range c.orders {
+		if params != nil && params.Status != "" {
+			if params.Status == "open" && order.Status == OrderStatusFilled {
+				continue
+			}
+			if params.Status == "closed" && order.Status != OrderStatusFilled {
+				continue
+			}
+		}
+		orders = append(orders, *order)
+	}
+	return orders, nil
+}
+
+// CancelOrder cancels a mock order
+func (c *MockClient) CancelOrder(ctx context.Context, orderID string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	order, exists := c.orders[orderID]
+	if !exists {
+		return fmt.Errorf("order not found: %s", orderID)
+	}
+
+	if order.Status == OrderStatusFilled {
+		return fmt.Errorf("cannot cancel filled order")
+	}
+
+	order.Status = OrderStatusCanceled
+	now := time.Now()
+	order.CanceledAt = &now
+	return nil
+}
+
+// CancelAllOrders cancels all open mock orders
+func (c *MockClient) CancelAllOrders(ctx context.Context) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	now := time.Now()
+	for _, order := range c.orders {
+		if order.Status != OrderStatusFilled {
+			order.Status = OrderStatusCanceled
+			order.CanceledAt = &now
+		}
+	}
+	return nil
+}
+
+// ReplaceOrder modifies a mock order
+func (c *MockClient) ReplaceOrder(ctx context.Context, orderID string, req *ReplaceOrderRequest) (*Order, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	order, exists := c.orders[orderID]
+	if !exists {
+		return nil, fmt.Errorf("order not found: %s", orderID)
+	}
+
+	if order.Status == OrderStatusFilled {
+		return nil, fmt.Errorf("cannot replace filled order")
+	}
+
+	// Create new order with replaced values
+	newOrderID := uuid.New().String()
+	newOrder := &Order{
+		ID:            newOrderID,
+		ClientOrderID: req.ClientOrderID,
+		CreatedAt:     time.Now(),
+		UpdatedAt:     time.Now(),
+		SubmittedAt:   time.Now(),
+		Symbol:        order.Symbol,
+		AssetClass:    order.AssetClass,
+		Qty:           req.Qty,
+		OrderType:     order.OrderType,
+		Side:          order.Side,
+		TimeInForce:   req.TimeInForce,
+		LimitPrice:    req.LimitPrice,
+		StopPrice:     req.StopPrice,
+		Status:        OrderStatusNew,
+		Replaces:      &orderID,
+	}
+
+	// Mark old order as replaced
+	order.Status = OrderStatusReplaced
+	order.ReplacedBy = &newOrderID
+	now := time.Now()
+	order.ReplacedAt = &now
+
+	c.orders[newOrderID] = newOrder
+	return newOrder, nil
+}
+
+// ListPositions returns all mock positions
+func (c *MockClient) ListPositions(ctx context.Context) ([]Position, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	positions := make([]Position, 0, len(c.positions))
+	for _, pos := range c.positions {
+		positions = append(positions, *pos)
+	}
+	return positions, nil
+}
+
+// GetPosition retrieves a specific mock position
+func (c *MockClient) GetPosition(ctx context.Context, symbol string) (*Position, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	pos, exists := c.positions[symbol]
+	if !exists {
+		return nil, fmt.Errorf("position not found: %s", symbol)
+	}
+	return pos, nil
+}
+
+// ClosePosition closes a mock position
+func (c *MockClient) ClosePosition(ctx context.Context, symbol string, qty string) (*Order, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	pos, exists := c.positions[symbol]
+	if !exists {
+		return nil, fmt.Errorf("position not found: %s", symbol)
+	}
+
+	// Create sell order
+	orderID := uuid.New().String()
+	now := time.Now()
+	order := &Order{
+		ID:             orderID,
+		ClientOrderID:  uuid.New().String(),
+		CreatedAt:      now,
+		UpdatedAt:      now,
+		SubmittedAt:    now,
+		FilledAt:       &now,
+		Symbol:         symbol,
+		AssetClass:     "us_equity",
+		Qty:            pos.Qty,
+		FilledQty:      pos.Qty,
+		FilledAvgPrice: pos.CurrentPrice,
+		OrderType:      Market,
+		Side:           Sell,
+		TimeInForce:    Day,
+		Status:         OrderStatusFilled,
+	}
+
+	c.orders[orderID] = order
+	delete(c.positions, symbol)
+
+	return order, nil
+}
+
+// CloseAllPositions closes all mock positions
+func (c *MockClient) CloseAllPositions(ctx context.Context, cancelOrders bool) ([]Order, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	orders := make([]Order, 0)
+	now := time.Now()
+
+	for symbol, pos := range c.positions {
+		orderID := uuid.New().String()
+		order := Order{
+			ID:             orderID,
+			ClientOrderID:  uuid.New().String(),
+			CreatedAt:      now,
+			UpdatedAt:      now,
+			SubmittedAt:    now,
+			FilledAt:       &now,
+			Symbol:         symbol,
+			AssetClass:     "us_equity",
+			Qty:            pos.Qty,
+			FilledQty:      pos.Qty,
+			FilledAvgPrice: pos.CurrentPrice,
+			OrderType:      Market,
+			Side:           Sell,
+			TimeInForce:    Day,
+			Status:         OrderStatusFilled,
+		}
+		orders = append(orders, order)
+		c.orders[orderID] = &order
+	}
+
+	c.positions = make(map[string]*Position)
+	return orders, nil
+}
+
+// GetAsset retrieves mock asset information
+func (c *MockClient) GetAsset(ctx context.Context, symbol string) (*Asset, error) {
+	return &Asset{
+		ID:           "mock-asset-" + symbol,
+		Class:        "us_equity",
+		Exchange:     "NASDAQ",
+		Symbol:       symbol,
+		Name:         symbol + " Inc.",
+		Status:       "active",
+		Tradable:     true,
+		Marginable:   true,
+		Shortable:    true,
+		EasyToBorrow: true,
+		Fractionable: true,
+	}, nil
+}
+
+// ListAssets returns a list of mock assets
+func (c *MockClient) ListAssets(ctx context.Context, params *ListAssetsParams) ([]Asset, error) {
+	assets := []Asset{
+		{ID: "1", Symbol: "AAPL", Name: "Apple Inc.", Class: "us_equity", Exchange: "NASDAQ", Status: "active", Tradable: true, Fractionable: true},
+		{ID: "2", Symbol: "GOOGL", Name: "Alphabet Inc.", Class: "us_equity", Exchange: "NASDAQ", Status: "active", Tradable: true, Fractionable: true},
+		{ID: "3", Symbol: "MSFT", Name: "Microsoft Corporation", Class: "us_equity", Exchange: "NASDAQ", Status: "active", Tradable: true, Fractionable: true},
+		{ID: "4", Symbol: "AMZN", Name: "Amazon.com Inc.", Class: "us_equity", Exchange: "NASDAQ", Status: "active", Tradable: true, Fractionable: true},
+		{ID: "5", Symbol: "TSLA", Name: "Tesla Inc.", Class: "us_equity", Exchange: "NASDAQ", Status: "active", Tradable: true, Fractionable: true},
+	}
+	return assets, nil
+}
+
+// GetQuote returns a mock quote
+func (c *MockClient) GetQuote(ctx context.Context, symbol string) (*Quote, error) {
+	return &Quote{
+		Symbol:    symbol,
+		BidPrice:  149.50,
+		BidSize:   100,
+		AskPrice:  150.50,
+		AskSize:   100,
+		Timestamp: time.Now().Format(time.RFC3339),
+	}, nil
+}
+
+// SetAccountCash sets the mock account cash balance (for testing)
+func (c *MockClient) SetAccountCash(cash string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.account.Cash = cash
+	c.account.BuyingPower = cash
+}
+
+// AddMockPosition adds a mock position (for testing)
+func (c *MockClient) AddMockPosition(symbol, qty, avgPrice string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.positions[symbol] = &Position{
+		Symbol:        symbol,
+		Qty:           qty,
+		AvgEntryPrice: avgPrice,
+		CurrentPrice:  avgPrice,
+		Side:          "long",
+		AssetClass:    "us_equity",
+	}
+}

--- a/pkg/alpaca/orders.go
+++ b/pkg/alpaca/orders.go
@@ -1,0 +1,242 @@
+package alpaca
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// OrderSide represents buy or sell
+type OrderSide string
+
+const (
+	Buy  OrderSide = "buy"
+	Sell OrderSide = "sell"
+)
+
+// OrderType represents the order type
+type OrderType string
+
+const (
+	Market        OrderType = "market"
+	Limit         OrderType = "limit"
+	Stop          OrderType = "stop"
+	StopLimit     OrderType = "stop_limit"
+	TrailingStop  OrderType = "trailing_stop"
+)
+
+// TimeInForce represents how long an order stays active
+type TimeInForce string
+
+const (
+	Day TimeInForce = "day" // Valid for the day only
+	GTC TimeInForce = "gtc" // Good til canceled
+	IOC TimeInForce = "ioc" // Immediate or cancel
+	FOK TimeInForce = "fok" // Fill or kill
+)
+
+// OrderStatus represents the current status of an order
+type OrderStatus string
+
+const (
+	OrderStatusNew             OrderStatus = "new"
+	OrderStatusPartiallyFilled OrderStatus = "partially_filled"
+	OrderStatusFilled          OrderStatus = "filled"
+	OrderStatusDoneForDay      OrderStatus = "done_for_day"
+	OrderStatusCanceled        OrderStatus = "canceled"
+	OrderStatusExpired         OrderStatus = "expired"
+	OrderStatusReplaced        OrderStatus = "replaced"
+	OrderStatusPendingCancel   OrderStatus = "pending_cancel"
+	OrderStatusPendingReplace  OrderStatus = "pending_replace"
+	OrderStatusAccepted        OrderStatus = "accepted"
+	OrderStatusPendingNew      OrderStatus = "pending_new"
+	OrderStatusAcceptedForBidding OrderStatus = "accepted_for_bidding"
+	OrderStatusStopped         OrderStatus = "stopped"
+	OrderStatusRejected        OrderStatus = "rejected"
+	OrderStatusSuspended       OrderStatus = "suspended"
+	OrderStatusCalculated      OrderStatus = "calculated"
+)
+
+// CreateOrderRequest represents an order submission request
+type CreateOrderRequest struct {
+	Symbol        string      `json:"symbol"`
+	Qty           string      `json:"qty,omitempty"`       // Number of shares (mutually exclusive with notional)
+	Notional      string      `json:"notional,omitempty"`  // Dollar amount for fractional shares
+	Side          OrderSide   `json:"side"`
+	Type          OrderType   `json:"type"`
+	TimeInForce   TimeInForce `json:"time_in_force"`
+	LimitPrice    string      `json:"limit_price,omitempty"`
+	StopPrice     string      `json:"stop_price,omitempty"`
+	ClientOrderID string      `json:"client_order_id,omitempty"`
+	ExtendedHours bool        `json:"extended_hours,omitempty"`
+}
+
+// Order represents an Alpaca order
+type Order struct {
+	ID             string      `json:"id"`
+	ClientOrderID  string      `json:"client_order_id"`
+	CreatedAt      time.Time   `json:"created_at"`
+	UpdatedAt      time.Time   `json:"updated_at"`
+	SubmittedAt    time.Time   `json:"submitted_at"`
+	FilledAt       *time.Time  `json:"filled_at"`
+	ExpiredAt      *time.Time  `json:"expired_at"`
+	CanceledAt     *time.Time  `json:"canceled_at"`
+	FailedAt       *time.Time  `json:"failed_at"`
+	ReplacedAt     *time.Time  `json:"replaced_at"`
+	ReplacedBy     *string     `json:"replaced_by"`
+	Replaces       *string     `json:"replaces"`
+	AssetID        string      `json:"asset_id"`
+	Symbol         string      `json:"symbol"`
+	AssetClass     string      `json:"asset_class"`
+	Qty            string      `json:"qty"`
+	FilledQty      string      `json:"filled_qty"`
+	FilledAvgPrice string      `json:"filled_avg_price"`
+	OrderClass     string      `json:"order_class"`
+	OrderType      OrderType   `json:"type"`
+	Side           OrderSide   `json:"side"`
+	TimeInForce    TimeInForce `json:"time_in_force"`
+	LimitPrice     string      `json:"limit_price"`
+	StopPrice      string      `json:"stop_price"`
+	Status         OrderStatus `json:"status"`
+	ExtendedHours  bool        `json:"extended_hours"`
+	Notional       string      `json:"notional"`
+}
+
+// CreateOrder submits a new order to Alpaca
+func (c *Client) CreateOrder(ctx context.Context, req *CreateOrderRequest) (*Order, error) {
+	url := fmt.Sprintf("%s/v2/orders", c.baseURL)
+	resp, err := c.doRequest(ctx, "POST", url, req)
+	if err != nil {
+		return nil, err
+	}
+
+	var order Order
+	if err := decodeResponse(resp, &order); err != nil {
+		return nil, err
+	}
+
+	return &order, nil
+}
+
+// GetOrder retrieves an order by ID
+func (c *Client) GetOrder(ctx context.Context, orderID string) (*Order, error) {
+	url := fmt.Sprintf("%s/v2/orders/%s", c.baseURL, orderID)
+	resp, err := c.doRequest(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var order Order
+	if err := decodeResponse(resp, &order); err != nil {
+		return nil, err
+	}
+
+	return &order, nil
+}
+
+// GetOrderByClientID retrieves an order by client order ID
+func (c *Client) GetOrderByClientID(ctx context.Context, clientOrderID string) (*Order, error) {
+	url := fmt.Sprintf("%s/v2/orders:by_client_order_id?client_order_id=%s", c.baseURL, clientOrderID)
+	resp, err := c.doRequest(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var order Order
+	if err := decodeResponse(resp, &order); err != nil {
+		return nil, err
+	}
+
+	return &order, nil
+}
+
+// ListOrdersParams contains parameters for listing orders
+type ListOrdersParams struct {
+	Status    string // open, closed, all
+	Limit     int
+	After     *time.Time
+	Until     *time.Time
+	Direction string // asc, desc
+	Nested    bool
+	Symbols   string // comma-separated
+}
+
+// ListOrders retrieves a list of orders
+func (c *Client) ListOrders(ctx context.Context, params *ListOrdersParams) ([]Order, error) {
+	url := fmt.Sprintf("%s/v2/orders", c.baseURL)
+	if params != nil {
+		query := "?"
+		if params.Status != "" {
+			query += fmt.Sprintf("status=%s&", params.Status)
+		}
+		if params.Limit > 0 {
+			query += fmt.Sprintf("limit=%d&", params.Limit)
+		}
+		if params.Direction != "" {
+			query += fmt.Sprintf("direction=%s&", params.Direction)
+		}
+		if params.Symbols != "" {
+			query += fmt.Sprintf("symbols=%s&", params.Symbols)
+		}
+		url += query
+	}
+
+	resp, err := c.doRequest(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var orders []Order
+	if err := decodeResponse(resp, &orders); err != nil {
+		return nil, err
+	}
+
+	return orders, nil
+}
+
+// CancelOrder cancels an open order by ID
+func (c *Client) CancelOrder(ctx context.Context, orderID string) error {
+	url := fmt.Sprintf("%s/v2/orders/%s", c.baseURL, orderID)
+	resp, err := c.doRequest(ctx, "DELETE", url, nil)
+	if err != nil {
+		return err
+	}
+
+	return decodeResponse(resp, nil)
+}
+
+// CancelAllOrders cancels all open orders
+func (c *Client) CancelAllOrders(ctx context.Context) error {
+	url := fmt.Sprintf("%s/v2/orders", c.baseURL)
+	resp, err := c.doRequest(ctx, "DELETE", url, nil)
+	if err != nil {
+		return err
+	}
+
+	return decodeResponse(resp, nil)
+}
+
+// ReplaceOrderRequest contains fields for modifying an existing order
+type ReplaceOrderRequest struct {
+	Qty           string      `json:"qty,omitempty"`
+	TimeInForce   TimeInForce `json:"time_in_force,omitempty"`
+	LimitPrice    string      `json:"limit_price,omitempty"`
+	StopPrice     string      `json:"stop_price,omitempty"`
+	ClientOrderID string      `json:"client_order_id,omitempty"`
+}
+
+// ReplaceOrder modifies an existing order
+func (c *Client) ReplaceOrder(ctx context.Context, orderID string, req *ReplaceOrderRequest) (*Order, error) {
+	url := fmt.Sprintf("%s/v2/orders/%s", c.baseURL, orderID)
+	resp, err := c.doRequest(ctx, "PATCH", url, req)
+	if err != nil {
+		return nil, err
+	}
+
+	var order Order
+	if err := decodeResponse(resp, &order); err != nil {
+		return nil, err
+	}
+
+	return &order, nil
+}

--- a/pkg/alpaca/positions.go
+++ b/pkg/alpaca/positions.go
@@ -1,0 +1,189 @@
+package alpaca
+
+import (
+	"context"
+	"fmt"
+)
+
+// Position represents a current holding
+type Position struct {
+	AssetID           string `json:"asset_id"`
+	Symbol            string `json:"symbol"`
+	Exchange          string `json:"exchange"`
+	AssetClass        string `json:"asset_class"`
+	AssetMarginable   bool   `json:"asset_marginable"`
+	Qty               string `json:"qty"`
+	AvgEntryPrice     string `json:"avg_entry_price"`
+	Side              string `json:"side"`
+	MarketValue       string `json:"market_value"`
+	CostBasis         string `json:"cost_basis"`
+	UnrealizedPL      string `json:"unrealized_pl"`
+	UnrealizedPLPC    string `json:"unrealized_plpc"`
+	UnrealizedIntradayPL   string `json:"unrealized_intraday_pl"`
+	UnrealizedIntradayPLPC string `json:"unrealized_intraday_plpc"`
+	CurrentPrice      string `json:"current_price"`
+	LastdayPrice      string `json:"lastday_price"`
+	ChangeToday       string `json:"change_today"`
+	QtyAvailable      string `json:"qty_available"`
+}
+
+// ListPositions retrieves all open positions
+func (c *Client) ListPositions(ctx context.Context) ([]Position, error) {
+	url := fmt.Sprintf("%s/v2/positions", c.baseURL)
+	resp, err := c.doRequest(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var positions []Position
+	if err := decodeResponse(resp, &positions); err != nil {
+		return nil, err
+	}
+
+	return positions, nil
+}
+
+// GetPosition retrieves a specific position by symbol
+func (c *Client) GetPosition(ctx context.Context, symbol string) (*Position, error) {
+	url := fmt.Sprintf("%s/v2/positions/%s", c.baseURL, symbol)
+	resp, err := c.doRequest(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var position Position
+	if err := decodeResponse(resp, &position); err != nil {
+		return nil, err
+	}
+
+	return &position, nil
+}
+
+// ClosePosition closes (liquidates) a position by symbol
+func (c *Client) ClosePosition(ctx context.Context, symbol string, qty string) (*Order, error) {
+	url := fmt.Sprintf("%s/v2/positions/%s", c.baseURL, symbol)
+	if qty != "" {
+		url += fmt.Sprintf("?qty=%s", qty)
+	}
+
+	resp, err := c.doRequest(ctx, "DELETE", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var order Order
+	if err := decodeResponse(resp, &order); err != nil {
+		return nil, err
+	}
+
+	return &order, nil
+}
+
+// CloseAllPositions closes all open positions
+func (c *Client) CloseAllPositions(ctx context.Context, cancelOrders bool) ([]Order, error) {
+	url := fmt.Sprintf("%s/v2/positions?cancel_orders=%t", c.baseURL, cancelOrders)
+	resp, err := c.doRequest(ctx, "DELETE", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var orders []Order
+	if err := decodeResponse(resp, &orders); err != nil {
+		return nil, err
+	}
+
+	return orders, nil
+}
+
+// Asset represents a tradeable asset
+type Asset struct {
+	ID           string `json:"id"`
+	Class        string `json:"class"`
+	Exchange     string `json:"exchange"`
+	Symbol       string `json:"symbol"`
+	Name         string `json:"name"`
+	Status       string `json:"status"`
+	Tradable     bool   `json:"tradable"`
+	Marginable   bool   `json:"marginable"`
+	Shortable    bool   `json:"shortable"`
+	EasyToBorrow bool   `json:"easy_to_borrow"`
+	Fractionable bool   `json:"fractionable"`
+}
+
+// GetAsset retrieves asset information by symbol
+func (c *Client) GetAsset(ctx context.Context, symbol string) (*Asset, error) {
+	url := fmt.Sprintf("%s/v2/assets/%s", c.baseURL, symbol)
+	resp, err := c.doRequest(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var asset Asset
+	if err := decodeResponse(resp, &asset); err != nil {
+		return nil, err
+	}
+
+	return &asset, nil
+}
+
+// ListAssetsParams contains parameters for listing assets
+type ListAssetsParams struct {
+	Status     string // active, inactive
+	AssetClass string // us_equity, crypto
+}
+
+// ListAssets retrieves a list of tradeable assets
+func (c *Client) ListAssets(ctx context.Context, params *ListAssetsParams) ([]Asset, error) {
+	url := fmt.Sprintf("%s/v2/assets", c.baseURL)
+	if params != nil {
+		query := "?"
+		if params.Status != "" {
+			query += fmt.Sprintf("status=%s&", params.Status)
+		}
+		if params.AssetClass != "" {
+			query += fmt.Sprintf("asset_class=%s&", params.AssetClass)
+		}
+		url += query
+	}
+
+	resp, err := c.doRequest(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var assets []Asset
+	if err := decodeResponse(resp, &assets); err != nil {
+		return nil, err
+	}
+
+	return assets, nil
+}
+
+// Quote represents current market data for an asset
+type Quote struct {
+	Symbol    string  `json:"symbol"`
+	BidPrice  float64 `json:"bid_price"`
+	BidSize   int     `json:"bid_size"`
+	AskPrice  float64 `json:"ask_price"`
+	AskSize   int     `json:"ask_size"`
+	Timestamp string  `json:"timestamp"`
+}
+
+// GetQuote retrieves the latest quote for a symbol
+func (c *Client) GetQuote(ctx context.Context, symbol string) (*Quote, error) {
+	url := fmt.Sprintf("%s/v2/stocks/%s/quotes/latest", c.dataURL, symbol)
+	resp, err := c.doRequest(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var result struct {
+		Quote Quote `json:"quote"`
+	}
+	if err := decodeResponse(resp, &result); err != nil {
+		return nil, err
+	}
+
+	result.Quote.Symbol = symbol
+	return &result.Quote, nil
+}

--- a/services/trading-service/internal/handler/handler.go
+++ b/services/trading-service/internal/handler/handler.go
@@ -1,0 +1,552 @@
+package handler
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/google/uuid"
+
+	"github.com/Rohianon/equishare-global-trading/pkg/alpaca"
+	apperrors "github.com/Rohianon/equishare-global-trading/pkg/errors"
+	"github.com/Rohianon/equishare-global-trading/pkg/events"
+	"github.com/Rohianon/equishare-global-trading/pkg/logger"
+	"github.com/Rohianon/equishare-global-trading/services/trading-service/internal/repository"
+	"github.com/Rohianon/equishare-global-trading/services/trading-service/internal/types"
+)
+
+// Handler handles trading HTTP requests
+type Handler struct {
+	userRepo    *repository.UserRepository
+	walletRepo  *repository.WalletRepository
+	orderRepo   *repository.OrderRepository
+	holdingRepo *repository.HoldingRepository
+	alpaca      alpaca.TradingClient
+	publisher   events.Publisher
+}
+
+// New creates a new trading handler
+func New(
+	userRepo *repository.UserRepository,
+	walletRepo *repository.WalletRepository,
+	orderRepo *repository.OrderRepository,
+	holdingRepo *repository.HoldingRepository,
+	alpacaClient alpaca.TradingClient,
+	publisher events.Publisher,
+) *Handler {
+	return &Handler{
+		userRepo:    userRepo,
+		walletRepo:  walletRepo,
+		orderRepo:   orderRepo,
+		holdingRepo: holdingRepo,
+		alpaca:      alpacaClient,
+		publisher:   publisher,
+	}
+}
+
+// PlaceOrder handles order placement
+func (h *Handler) PlaceOrder(c *fiber.Ctx) error {
+	userID := c.Locals("user_id").(string)
+
+	var req types.PlaceOrderRequest
+	if err := c.BodyParser(&req); err != nil {
+		return apperrors.ErrValidation.WithDetails("Invalid request body")
+	}
+
+	if req.Symbol == "" {
+		return apperrors.ErrValidation.WithDetails("Symbol is required")
+	}
+	if req.Side != "buy" && req.Side != "sell" {
+		return apperrors.ErrValidation.WithDetails("Side must be 'buy' or 'sell'")
+	}
+	if req.Amount <= 0 && req.Qty <= 0 {
+		return apperrors.ErrValidation.WithDetails("Amount or qty is required")
+	}
+
+	ctx := c.Context()
+
+	// Verify user exists and is active
+	user, err := h.userRepo.GetByID(ctx, userID)
+	if err != nil {
+		logger.Error().Err(err).Str("user_id", userID).Msg("Failed to get user")
+		return apperrors.ErrInternal
+	}
+	if !user.IsActive {
+		return apperrors.ErrForbidden.WithDetails("Account is deactivated")
+	}
+
+	// Get USD wallet for balance checks
+	wallet, err := h.walletRepo.GetByUserAndCurrency(ctx, userID, "USD")
+	if err != nil {
+		logger.Error().Err(err).Str("user_id", userID).Msg("Failed to get wallet")
+		return apperrors.ErrInternal
+	}
+
+	// For buy orders, check and lock funds
+	if req.Side == "buy" {
+		amount := req.Amount
+		if amount <= 0 {
+			// If qty specified, estimate the amount (we'll use actual at fill)
+			quote, err := h.alpaca.GetQuote(ctx, req.Symbol)
+			if err != nil {
+				return apperrors.ErrServiceUnavailable.WithDetails("Failed to get quote")
+			}
+			amount = req.Qty * quote.AskPrice * 1.01 // Add 1% buffer
+		}
+
+		if wallet.AvailableBalance() < amount {
+			return apperrors.ErrValidation.WithDetails("Insufficient balance")
+		}
+
+		if err := h.walletRepo.Lock(ctx, wallet.ID, amount); err != nil {
+			return apperrors.ErrInternal.WithDetails("Failed to lock funds")
+		}
+	}
+
+	// For sell orders, check holdings
+	if req.Side == "sell" {
+		if req.Qty <= 0 {
+			return apperrors.ErrValidation.WithDetails("Qty is required for sell orders")
+		}
+
+		hasSufficient, err := h.holdingRepo.HasSufficientQty(ctx, userID, req.Symbol, req.Qty)
+		if err != nil || !hasSufficient {
+			return apperrors.ErrValidation.WithDetails("Insufficient shares to sell")
+		}
+	}
+
+	// Submit order to Alpaca
+	clientOrderID := uuid.New().String()
+	alpacaReq := &alpaca.CreateOrderRequest{
+		Symbol:        req.Symbol,
+		Side:          alpaca.OrderSide(req.Side),
+		Type:          alpaca.Market,
+		TimeInForce:   alpaca.Day,
+		ClientOrderID: clientOrderID,
+	}
+
+	if req.Amount > 0 {
+		alpacaReq.Notional = fmt.Sprintf("%.2f", req.Amount)
+	} else {
+		alpacaReq.Qty = fmt.Sprintf("%.6f", req.Qty)
+	}
+
+	alpacaOrder, err := h.alpaca.CreateOrder(ctx, alpacaReq)
+	if err != nil {
+		logger.Error().Err(err).Str("user_id", userID).Str("symbol", req.Symbol).Msg("Failed to create Alpaca order")
+		// Unlock funds on failure
+		if req.Side == "buy" {
+			h.walletRepo.Unlock(ctx, wallet.ID, req.Amount)
+		}
+		return apperrors.ErrServiceUnavailable.WithDetails("Failed to place order")
+	}
+
+	// Save order to database
+	order := &types.Order{
+		UserID:        userID,
+		AlpacaOrderID: alpacaOrder.ID,
+		Symbol:        req.Symbol,
+		Side:          req.Side,
+		Type:          "market",
+		Amount:        req.Amount,
+		Qty:           req.Qty,
+		Status:        "pending",
+		Source:        req.Source,
+	}
+	if order.Source == "" {
+		order.Source = "api"
+	}
+
+	if err := h.orderRepo.Create(ctx, order); err != nil {
+		logger.Error().Err(err).Msg("Failed to save order to database")
+		// Order was placed with Alpaca, log but continue
+	}
+
+	// Publish order created event
+	if h.publisher != nil {
+		h.publisher.Publish(ctx, events.TopicOrderCreated, &events.Event{
+			Type:   "order.created",
+			Source: "trading-service",
+			Data: map[string]any{
+				"order_id":       order.ID,
+				"user_id":        userID,
+				"symbol":         req.Symbol,
+				"side":           req.Side,
+				"amount":         req.Amount,
+				"alpaca_order_id": alpacaOrder.ID,
+			},
+		})
+	}
+
+	logger.Info().
+		Str("user_id", userID).
+		Str("order_id", order.ID).
+		Str("symbol", req.Symbol).
+		Str("side", req.Side).
+		Msg("Order placed successfully")
+
+	return c.Status(fiber.StatusCreated).JSON(types.PlaceOrderResponse{
+		OrderID:       order.ID,
+		AlpacaOrderID: alpacaOrder.ID,
+		Symbol:        req.Symbol,
+		Side:          req.Side,
+		Amount:        req.Amount,
+		Status:        string(alpacaOrder.Status),
+		Message:       "Order placed successfully",
+	})
+}
+
+// CancelOrder cancels an open order
+func (h *Handler) CancelOrder(c *fiber.Ctx) error {
+	userID := c.Locals("user_id").(string)
+	orderID := c.Params("id")
+
+	ctx := c.Context()
+
+	order, err := h.orderRepo.GetByID(ctx, orderID)
+	if err != nil {
+		return apperrors.ErrNotFound.WithDetails("Order not found")
+	}
+
+	if order.UserID != userID {
+		return apperrors.ErrForbidden.WithDetails("Not your order")
+	}
+
+	if order.Status != "pending" && order.Status != "new" {
+		return apperrors.ErrValidation.WithDetails("Order cannot be canceled")
+	}
+
+	if err := h.alpaca.CancelOrder(ctx, order.AlpacaOrderID); err != nil {
+		logger.Error().Err(err).Str("order_id", orderID).Msg("Failed to cancel Alpaca order")
+		return apperrors.ErrServiceUnavailable.WithDetails("Failed to cancel order")
+	}
+
+	if err := h.orderRepo.UpdateStatus(ctx, orderID, "canceled"); err != nil {
+		logger.Error().Err(err).Msg("Failed to update order status")
+	}
+
+	// Unlock funds for buy orders
+	if order.Side == "buy" && order.Amount > 0 {
+		wallet, _ := h.walletRepo.GetByUserAndCurrency(ctx, userID, "USD")
+		if wallet != nil {
+			h.walletRepo.Unlock(ctx, wallet.ID, order.Amount)
+		}
+	}
+
+	logger.Info().Str("order_id", orderID).Msg("Order canceled")
+
+	return c.JSON(types.CancelOrderResponse{
+		OrderID: orderID,
+		Status:  "canceled",
+		Message: "Order canceled successfully",
+	})
+}
+
+// GetOrder retrieves an order by ID
+func (h *Handler) GetOrder(c *fiber.Ctx) error {
+	userID := c.Locals("user_id").(string)
+	orderID := c.Params("id")
+
+	order, err := h.orderRepo.GetByID(c.Context(), orderID)
+	if err != nil {
+		return apperrors.ErrNotFound.WithDetails("Order not found")
+	}
+
+	if order.UserID != userID {
+		return apperrors.ErrForbidden.WithDetails("Not your order")
+	}
+
+	return c.JSON(order)
+}
+
+// ListOrders retrieves orders for the user
+func (h *Handler) ListOrders(c *fiber.Ctx) error {
+	userID := c.Locals("user_id").(string)
+	status := c.Query("status")
+	limit := c.QueryInt("limit", 50)
+
+	orders, err := h.orderRepo.ListByUser(c.Context(), userID, status, limit)
+	if err != nil {
+		logger.Error().Err(err).Msg("Failed to list orders")
+		return apperrors.ErrInternal
+	}
+
+	return c.JSON(fiber.Map{
+		"orders": orders,
+		"count":  len(orders),
+	})
+}
+
+// GetPortfolio retrieves the user's portfolio
+func (h *Handler) GetPortfolio(c *fiber.Ctx) error {
+	userID := c.Locals("user_id").(string)
+	ctx := c.Context()
+
+	holdings, err := h.holdingRepo.ListByUser(ctx, userID)
+	if err != nil {
+		logger.Error().Err(err).Msg("Failed to list holdings")
+		return apperrors.ErrInternal
+	}
+
+	// Get current prices and calculate P&L
+	var totalValue, totalPL float64
+	for i := range holdings {
+		quote, err := h.alpaca.GetQuote(ctx, holdings[i].Symbol)
+		if err == nil {
+			midPrice := (quote.BidPrice + quote.AskPrice) / 2
+			holdings[i].CurrentPrice = midPrice
+			holdings[i].MarketValue = holdings[i].Qty * midPrice
+			holdings[i].UnrealizedPL = (midPrice - holdings[i].AvgEntryPrice) * holdings[i].Qty
+			if holdings[i].AvgEntryPrice > 0 {
+				holdings[i].UnrealizedPLPct = (midPrice/holdings[i].AvgEntryPrice - 1) * 100
+			}
+		}
+		totalValue += holdings[i].MarketValue
+		totalPL += holdings[i].UnrealizedPL
+	}
+
+	// Get cash balance
+	wallet, _ := h.walletRepo.GetByUserAndCurrency(ctx, userID, "USD")
+	cashUSD := 0.0
+	if wallet != nil {
+		cashUSD = wallet.Balance
+	}
+
+	costBasis := totalValue - totalPL
+	totalPLPct := 0.0
+	if costBasis > 0 {
+		totalPLPct = (totalPL / costBasis) * 100
+	}
+
+	return c.JSON(types.Portfolio{
+		Holdings:   holdings,
+		TotalValue: totalValue,
+		TotalPL:    totalPL,
+		TotalPLPct: totalPLPct,
+		CashUSD:    cashUSD,
+	})
+}
+
+// GetQuote retrieves a stock quote
+func (h *Handler) GetQuote(c *fiber.Ctx) error {
+	symbol := c.Params("symbol")
+	if symbol == "" {
+		return apperrors.ErrValidation.WithDetails("Symbol is required")
+	}
+
+	quote, err := h.alpaca.GetQuote(c.Context(), symbol)
+	if err != nil {
+		return apperrors.ErrNotFound.WithDetails("Quote not found")
+	}
+
+	lastPrice := (quote.BidPrice + quote.AskPrice) / 2
+
+	return c.JSON(types.QuoteResponse{
+		Symbol:    symbol,
+		BidPrice:  quote.BidPrice,
+		AskPrice:  quote.AskPrice,
+		LastPrice: lastPrice,
+	})
+}
+
+// SearchAssets searches for tradeable assets
+func (h *Handler) SearchAssets(c *fiber.Ctx) error {
+	query := c.Query("q")
+	if query == "" {
+		return apperrors.ErrValidation.WithDetails("Search query is required")
+	}
+
+	assets, err := h.alpaca.ListAssets(c.Context(), &alpaca.ListAssetsParams{
+		Status:     "active",
+		AssetClass: "us_equity",
+	})
+	if err != nil {
+		return apperrors.ErrServiceUnavailable.WithDetails("Failed to search assets")
+	}
+
+	// Filter by query (simple substring match)
+	var results []types.AssetInfo
+	for _, a := range assets {
+		if containsIgnoreCase(a.Symbol, query) || containsIgnoreCase(a.Name, query) {
+			results = append(results, types.AssetInfo{
+				Symbol:       a.Symbol,
+				Name:         a.Name,
+				Exchange:     a.Exchange,
+				Tradable:     a.Tradable,
+				Fractionable: a.Fractionable,
+			})
+			if len(results) >= 20 {
+				break
+			}
+		}
+	}
+
+	return c.JSON(types.SearchResponse{Assets: results})
+}
+
+// AlpacaWebhook handles order updates from Alpaca
+func (h *Handler) AlpacaWebhook(c *fiber.Ctx) error {
+	var event types.AlpacaWebhookEvent
+	if err := c.BodyParser(&event); err != nil {
+		logger.Error().Err(err).Msg("Failed to parse Alpaca webhook")
+		return c.SendStatus(fiber.StatusOK)
+	}
+
+	ctx := c.Context()
+
+	logger.Info().
+		Str("event", event.Event).
+		Str("order_id", event.Order.ID).
+		Str("status", event.Order.Status).
+		Msg("Received Alpaca webhook")
+
+	order, err := h.orderRepo.GetByAlpacaOrderID(ctx, event.Order.ID)
+	if err != nil {
+		logger.Warn().Str("alpaca_order_id", event.Order.ID).Msg("Order not found in database")
+		return c.SendStatus(fiber.StatusOK)
+	}
+
+	switch event.Event {
+	case "fill":
+		h.handleOrderFill(ctx, order, &event.Order)
+	case "partial_fill":
+		h.handlePartialFill(ctx, order, &event.Order)
+	case "canceled":
+		h.handleOrderCanceled(ctx, order)
+	case "rejected":
+		h.handleOrderRejected(ctx, order, "Order rejected by exchange")
+	}
+
+	return c.SendStatus(fiber.StatusOK)
+}
+
+func (h *Handler) handleOrderFill(ctx context.Context, order *types.Order, alpacaOrder *types.AlpacaOrderUpdate) {
+	filledQty, _ := strconv.ParseFloat(alpacaOrder.FilledQty, 64)
+	filledAvgPrice, _ := strconv.ParseFloat(alpacaOrder.FilledAvgPrice, 64)
+
+	if err := h.orderRepo.UpdateFill(ctx, order.AlpacaOrderID, filledQty, filledAvgPrice, "filled"); err != nil {
+		logger.Error().Err(err).Msg("Failed to update order fill")
+	}
+
+	// Update holdings
+	if order.Side == "buy" {
+		h.holdingRepo.Upsert(ctx, order.UserID, order.Symbol, filledQty, filledAvgPrice)
+
+		// Debit wallet
+		wallet, _ := h.walletRepo.GetByUserAndCurrency(ctx, order.UserID, "USD")
+		if wallet != nil {
+			totalCost := filledQty * filledAvgPrice
+			h.walletRepo.DebitLocked(ctx, wallet.ID, totalCost)
+			// Unlock any excess that was locked
+			if order.Amount > totalCost {
+				h.walletRepo.Unlock(ctx, wallet.ID, order.Amount-totalCost)
+			}
+		}
+	} else {
+		// Sell order - reduce holdings and credit wallet
+		h.holdingRepo.ReduceQty(ctx, order.UserID, order.Symbol, filledQty)
+
+		wallet, _ := h.walletRepo.GetByUserAndCurrency(ctx, order.UserID, "USD")
+		if wallet != nil {
+			proceeds := filledQty * filledAvgPrice
+			h.walletRepo.Credit(ctx, wallet.ID, proceeds)
+		}
+	}
+
+	// Publish event
+	if h.publisher != nil {
+		h.publisher.Publish(ctx, events.TopicOrderFilled, &events.Event{
+			Type:   "order.filled",
+			Source: "trading-service",
+			Data: map[string]any{
+				"order_id":         order.ID,
+				"user_id":          order.UserID,
+				"symbol":           order.Symbol,
+				"side":             order.Side,
+				"filled_qty":       filledQty,
+				"filled_avg_price": filledAvgPrice,
+			},
+		})
+	}
+
+	logger.Info().
+		Str("order_id", order.ID).
+		Float64("filled_qty", filledQty).
+		Float64("filled_avg_price", filledAvgPrice).
+		Msg("Order filled")
+}
+
+func (h *Handler) handlePartialFill(ctx context.Context, order *types.Order, alpacaOrder *types.AlpacaOrderUpdate) {
+	filledQty, _ := strconv.ParseFloat(alpacaOrder.FilledQty, 64)
+	filledAvgPrice, _ := strconv.ParseFloat(alpacaOrder.FilledAvgPrice, 64)
+
+	if err := h.orderRepo.UpdateFill(ctx, order.AlpacaOrderID, filledQty, filledAvgPrice, "partial_fill"); err != nil {
+		logger.Error().Err(err).Msg("Failed to update partial fill")
+	}
+
+	logger.Info().
+		Str("order_id", order.ID).
+		Float64("filled_qty", filledQty).
+		Msg("Order partially filled")
+}
+
+func (h *Handler) handleOrderCanceled(ctx context.Context, order *types.Order) {
+	if err := h.orderRepo.UpdateCanceled(ctx, order.AlpacaOrderID); err != nil {
+		logger.Error().Err(err).Msg("Failed to update order canceled")
+	}
+
+	// Unlock funds for buy orders
+	if order.Side == "buy" && order.Amount > 0 {
+		wallet, _ := h.walletRepo.GetByUserAndCurrency(ctx, order.UserID, "USD")
+		if wallet != nil {
+			h.walletRepo.Unlock(ctx, wallet.ID, order.Amount)
+		}
+	}
+
+	logger.Info().Str("order_id", order.ID).Msg("Order canceled via webhook")
+}
+
+func (h *Handler) handleOrderRejected(ctx context.Context, order *types.Order, reason string) {
+	if err := h.orderRepo.UpdateFailed(ctx, order.AlpacaOrderID, reason); err != nil {
+		logger.Error().Err(err).Msg("Failed to update order rejected")
+	}
+
+	// Unlock funds for buy orders
+	if order.Side == "buy" && order.Amount > 0 {
+		wallet, _ := h.walletRepo.GetByUserAndCurrency(ctx, order.UserID, "USD")
+		if wallet != nil {
+			h.walletRepo.Unlock(ctx, wallet.ID, order.Amount)
+		}
+	}
+
+	logger.Info().Str("order_id", order.ID).Str("reason", reason).Msg("Order rejected")
+}
+
+func containsIgnoreCase(s, substr string) bool {
+	for i := 0; i+len(substr) <= len(s); i++ {
+		if equalIgnoreCase(s[i:i+len(substr)], substr) {
+			return true
+		}
+	}
+	return false
+}
+
+func equalIgnoreCase(a, b string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := 0; i < len(a); i++ {
+		ca, cb := a[i], b[i]
+		if ca >= 'A' && ca <= 'Z' {
+			ca += 32
+		}
+		if cb >= 'A' && cb <= 'Z' {
+			cb += 32
+		}
+		if ca != cb {
+			return false
+		}
+	}
+	return true
+}

--- a/services/trading-service/internal/repository/holding.go
+++ b/services/trading-service/internal/repository/holding.go
@@ -1,0 +1,131 @@
+package repository
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Rohianon/equishare-global-trading/services/trading-service/internal/types"
+)
+
+// HoldingRepository handles holding database operations
+type HoldingRepository struct {
+	db *pgxpool.Pool
+}
+
+// NewHoldingRepository creates a new holding repository
+func NewHoldingRepository(db *pgxpool.Pool) *HoldingRepository {
+	return &HoldingRepository{db: db}
+}
+
+// Upsert creates or updates a holding (after order fill)
+func (r *HoldingRepository) Upsert(ctx context.Context, userID, symbol string, qty, avgPrice float64) error {
+	_, err := r.db.Exec(ctx, `
+		INSERT INTO holdings (user_id, symbol, quantity, average_cost)
+		VALUES ($1, $2, $3, $4)
+		ON CONFLICT (user_id, symbol) DO UPDATE SET
+			quantity = holdings.quantity + EXCLUDED.quantity,
+			average_cost = CASE
+				WHEN holdings.quantity + EXCLUDED.quantity = 0 THEN 0
+				ELSE (holdings.quantity * holdings.average_cost + EXCLUDED.quantity * EXCLUDED.average_cost)
+				     / (holdings.quantity + EXCLUDED.quantity)
+			END,
+			updated_at = NOW()
+	`, userID, symbol, qty, avgPrice)
+
+	if err != nil {
+		return fmt.Errorf("failed to upsert holding: %w", err)
+	}
+
+	return nil
+}
+
+// GetByUserAndSymbol retrieves a specific holding
+func (r *HoldingRepository) GetByUserAndSymbol(ctx context.Context, userID, symbol string) (*types.Holding, error) {
+	var holding types.Holding
+	err := r.db.QueryRow(ctx, `
+		SELECT id, user_id, symbol, quantity, average_cost, created_at, updated_at
+		FROM holdings WHERE user_id = $1 AND symbol = $2
+	`, userID, symbol).Scan(
+		&holding.ID, &holding.UserID, &holding.Symbol, &holding.Qty,
+		&holding.AvgEntryPrice, &holding.CreatedAt, &holding.UpdatedAt,
+	)
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to get holding: %w", err)
+	}
+
+	return &holding, nil
+}
+
+// ListByUser retrieves all holdings for a user
+func (r *HoldingRepository) ListByUser(ctx context.Context, userID string) ([]types.Holding, error) {
+	rows, err := r.db.Query(ctx, `
+		SELECT id, user_id, symbol, quantity, average_cost, created_at, updated_at
+		FROM holdings WHERE user_id = $1 AND quantity > 0
+		ORDER BY symbol ASC
+	`, userID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list holdings: %w", err)
+	}
+	defer rows.Close()
+
+	var holdings []types.Holding
+	for rows.Next() {
+		var holding types.Holding
+		err := rows.Scan(
+			&holding.ID, &holding.UserID, &holding.Symbol, &holding.Qty,
+			&holding.AvgEntryPrice, &holding.CreatedAt, &holding.UpdatedAt,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan holding: %w", err)
+		}
+		holdings = append(holdings, holding)
+	}
+
+	return holdings, nil
+}
+
+// ReduceQty reduces the quantity of a holding (for sell orders)
+func (r *HoldingRepository) ReduceQty(ctx context.Context, userID, symbol string, qty float64) error {
+	_, err := r.db.Exec(ctx, `
+		UPDATE holdings
+		SET quantity = quantity - $1, updated_at = NOW()
+		WHERE user_id = $2 AND symbol = $3
+	`, qty, userID, symbol)
+
+	if err != nil {
+		return fmt.Errorf("failed to reduce holding qty: %w", err)
+	}
+
+	return nil
+}
+
+// Delete removes a holding (when qty reaches zero)
+func (r *HoldingRepository) Delete(ctx context.Context, userID, symbol string) error {
+	_, err := r.db.Exec(ctx, `
+		DELETE FROM holdings WHERE user_id = $1 AND symbol = $2
+	`, userID, symbol)
+
+	if err != nil {
+		return fmt.Errorf("failed to delete holding: %w", err)
+	}
+
+	return nil
+}
+
+// HasSufficientQty checks if user has enough shares to sell
+func (r *HoldingRepository) HasSufficientQty(ctx context.Context, userID, symbol string, qty float64) (bool, error) {
+	var holdingQty float64
+	err := r.db.QueryRow(ctx, `
+		SELECT COALESCE(quantity, 0) FROM holdings WHERE user_id = $1 AND symbol = $2
+	`, userID, symbol).Scan(&holdingQty)
+
+	if err != nil {
+		// No holding means 0 qty
+		return false, nil
+	}
+
+	return holdingQty >= qty, nil
+}

--- a/services/trading-service/internal/repository/order.go
+++ b/services/trading-service/internal/repository/order.go
@@ -1,0 +1,182 @@
+package repository
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Rohianon/equishare-global-trading/services/trading-service/internal/types"
+)
+
+// OrderRepository handles order database operations
+type OrderRepository struct {
+	db *pgxpool.Pool
+}
+
+// NewOrderRepository creates a new order repository
+func NewOrderRepository(db *pgxpool.Pool) *OrderRepository {
+	return &OrderRepository{db: db}
+}
+
+// Create creates a new order
+func (r *OrderRepository) Create(ctx context.Context, order *types.Order) error {
+	err := r.db.QueryRow(ctx, `
+		INSERT INTO orders (user_id, alpaca_order_id, symbol, side, type, amount, qty, status, source)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+		RETURNING id, created_at, updated_at
+	`, order.UserID, order.AlpacaOrderID, order.Symbol, order.Side, order.Type,
+		order.Amount, order.Qty, order.Status, order.Source,
+	).Scan(&order.ID, &order.CreatedAt, &order.UpdatedAt)
+
+	if err != nil {
+		return fmt.Errorf("failed to create order: %w", err)
+	}
+
+	return nil
+}
+
+// GetByID retrieves an order by ID
+func (r *OrderRepository) GetByID(ctx context.Context, orderID string) (*types.Order, error) {
+	var order types.Order
+	err := r.db.QueryRow(ctx, `
+		SELECT id, user_id, alpaca_order_id, symbol, side, type, amount, qty,
+		       filled_qty, filled_avg_price, status, source, failed_reason,
+		       filled_at, canceled_at, created_at, updated_at
+		FROM orders WHERE id = $1
+	`, orderID).Scan(
+		&order.ID, &order.UserID, &order.AlpacaOrderID, &order.Symbol, &order.Side,
+		&order.Type, &order.Amount, &order.Qty, &order.FilledQty, &order.FilledAvgPrice,
+		&order.Status, &order.Source, &order.FailedReason,
+		&order.FilledAt, &order.CanceledAt, &order.CreatedAt, &order.UpdatedAt,
+	)
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to get order: %w", err)
+	}
+
+	return &order, nil
+}
+
+// GetByAlpacaOrderID retrieves an order by Alpaca order ID
+func (r *OrderRepository) GetByAlpacaOrderID(ctx context.Context, alpacaOrderID string) (*types.Order, error) {
+	var order types.Order
+	err := r.db.QueryRow(ctx, `
+		SELECT id, user_id, alpaca_order_id, symbol, side, type, amount, qty,
+		       filled_qty, filled_avg_price, status, source, failed_reason,
+		       filled_at, canceled_at, created_at, updated_at
+		FROM orders WHERE alpaca_order_id = $1
+	`, alpacaOrderID).Scan(
+		&order.ID, &order.UserID, &order.AlpacaOrderID, &order.Symbol, &order.Side,
+		&order.Type, &order.Amount, &order.Qty, &order.FilledQty, &order.FilledAvgPrice,
+		&order.Status, &order.Source, &order.FailedReason,
+		&order.FilledAt, &order.CanceledAt, &order.CreatedAt, &order.UpdatedAt,
+	)
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to get order by alpaca ID: %w", err)
+	}
+
+	return &order, nil
+}
+
+// ListByUser retrieves orders for a user
+func (r *OrderRepository) ListByUser(ctx context.Context, userID string, status string, limit int) ([]types.Order, error) {
+	query := `
+		SELECT id, user_id, alpaca_order_id, symbol, side, type, amount, qty,
+		       filled_qty, filled_avg_price, status, source, failed_reason,
+		       filled_at, canceled_at, created_at, updated_at
+		FROM orders WHERE user_id = $1
+	`
+	args := []any{userID}
+
+	if status != "" {
+		query += " AND status = $2"
+		args = append(args, status)
+	}
+
+	query += " ORDER BY created_at DESC"
+
+	if limit > 0 {
+		query += fmt.Sprintf(" LIMIT %d", limit)
+	}
+
+	rows, err := r.db.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list orders: %w", err)
+	}
+	defer rows.Close()
+
+	var orders []types.Order
+	for rows.Next() {
+		var order types.Order
+		err := rows.Scan(
+			&order.ID, &order.UserID, &order.AlpacaOrderID, &order.Symbol, &order.Side,
+			&order.Type, &order.Amount, &order.Qty, &order.FilledQty, &order.FilledAvgPrice,
+			&order.Status, &order.Source, &order.FailedReason,
+			&order.FilledAt, &order.CanceledAt, &order.CreatedAt, &order.UpdatedAt,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan order: %w", err)
+		}
+		orders = append(orders, order)
+	}
+
+	return orders, nil
+}
+
+// UpdateStatus updates the order status
+func (r *OrderRepository) UpdateStatus(ctx context.Context, orderID, status string) error {
+	_, err := r.db.Exec(ctx, `
+		UPDATE orders SET status = $1, updated_at = NOW() WHERE id = $2
+	`, status, orderID)
+
+	if err != nil {
+		return fmt.Errorf("failed to update order status: %w", err)
+	}
+
+	return nil
+}
+
+// UpdateFill updates the order with fill information
+func (r *OrderRepository) UpdateFill(ctx context.Context, alpacaOrderID string, filledQty, filledAvgPrice float64, status string) error {
+	_, err := r.db.Exec(ctx, `
+		UPDATE orders
+		SET filled_qty = $1, filled_avg_price = $2, status = $3, filled_at = NOW(), updated_at = NOW()
+		WHERE alpaca_order_id = $4
+	`, filledQty, filledAvgPrice, status, alpacaOrderID)
+
+	if err != nil {
+		return fmt.Errorf("failed to update order fill: %w", err)
+	}
+
+	return nil
+}
+
+// UpdateCanceled marks the order as canceled
+func (r *OrderRepository) UpdateCanceled(ctx context.Context, alpacaOrderID string) error {
+	_, err := r.db.Exec(ctx, `
+		UPDATE orders SET status = 'canceled', canceled_at = NOW(), updated_at = NOW()
+		WHERE alpaca_order_id = $1
+	`, alpacaOrderID)
+
+	if err != nil {
+		return fmt.Errorf("failed to update order canceled: %w", err)
+	}
+
+	return nil
+}
+
+// UpdateFailed marks the order as failed
+func (r *OrderRepository) UpdateFailed(ctx context.Context, alpacaOrderID, reason string) error {
+	_, err := r.db.Exec(ctx, `
+		UPDATE orders SET status = 'failed', failed_reason = $1, updated_at = NOW()
+		WHERE alpaca_order_id = $2
+	`, reason, alpacaOrderID)
+
+	if err != nil {
+		return fmt.Errorf("failed to update order failed: %w", err)
+	}
+
+	return nil
+}

--- a/services/trading-service/internal/repository/user.go
+++ b/services/trading-service/internal/repository/user.go
@@ -1,0 +1,35 @@
+package repository
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Rohianon/equishare-global-trading/services/trading-service/internal/types"
+)
+
+// UserRepository handles user database operations for trading
+type UserRepository struct {
+	db *pgxpool.Pool
+}
+
+// NewUserRepository creates a new user repository
+func NewUserRepository(db *pgxpool.Pool) *UserRepository {
+	return &UserRepository{db: db}
+}
+
+// GetByID retrieves a user by ID
+func (r *UserRepository) GetByID(ctx context.Context, userID string) (*types.User, error) {
+	var user types.User
+	err := r.db.QueryRow(ctx, `
+		SELECT id, phone, is_active, is_kyc_verified
+		FROM users WHERE id = $1
+	`, userID).Scan(&user.ID, &user.Phone, &user.IsActive, &user.IsKYCVerified)
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to get user: %w", err)
+	}
+
+	return &user, nil
+}

--- a/services/trading-service/internal/repository/wallet.go
+++ b/services/trading-service/internal/repository/wallet.go
@@ -1,0 +1,103 @@
+package repository
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Rohianon/equishare-global-trading/services/trading-service/internal/types"
+)
+
+// WalletRepository handles wallet database operations for trading
+type WalletRepository struct {
+	db *pgxpool.Pool
+}
+
+// NewWalletRepository creates a new wallet repository
+func NewWalletRepository(db *pgxpool.Pool) *WalletRepository {
+	return &WalletRepository{db: db}
+}
+
+// GetByUserAndCurrency retrieves a wallet by user and currency
+func (r *WalletRepository) GetByUserAndCurrency(ctx context.Context, userID, currency string) (*types.Wallet, error) {
+	var wallet types.Wallet
+	err := r.db.QueryRow(ctx, `
+		SELECT id, user_id, currency, balance, locked_balance, created_at, updated_at
+		FROM wallets WHERE user_id = $1 AND currency = $2
+	`, userID, currency).Scan(
+		&wallet.ID, &wallet.UserID, &wallet.Currency,
+		&wallet.Balance, &wallet.LockedBalance,
+		&wallet.CreatedAt, &wallet.UpdatedAt,
+	)
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to get wallet: %w", err)
+	}
+
+	return &wallet, nil
+}
+
+// Lock locks funds for an order
+func (r *WalletRepository) Lock(ctx context.Context, walletID string, amount float64) error {
+	result, err := r.db.Exec(ctx, `
+		UPDATE wallets
+		SET locked_balance = locked_balance + $1, updated_at = NOW()
+		WHERE id = $2 AND balance - locked_balance >= $1
+	`, amount, walletID)
+
+	if err != nil {
+		return fmt.Errorf("failed to lock funds: %w", err)
+	}
+
+	if result.RowsAffected() == 0 {
+		return fmt.Errorf("insufficient balance to lock")
+	}
+
+	return nil
+}
+
+// Unlock unlocks previously locked funds (for canceled orders)
+func (r *WalletRepository) Unlock(ctx context.Context, walletID string, amount float64) error {
+	_, err := r.db.Exec(ctx, `
+		UPDATE wallets
+		SET locked_balance = locked_balance - $1, updated_at = NOW()
+		WHERE id = $2
+	`, amount, walletID)
+
+	if err != nil {
+		return fmt.Errorf("failed to unlock funds: %w", err)
+	}
+
+	return nil
+}
+
+// DebitLocked debits from locked balance (after order fills)
+func (r *WalletRepository) DebitLocked(ctx context.Context, walletID string, amount float64) error {
+	_, err := r.db.Exec(ctx, `
+		UPDATE wallets
+		SET balance = balance - $1, locked_balance = locked_balance - $1, updated_at = NOW()
+		WHERE id = $2
+	`, amount, walletID)
+
+	if err != nil {
+		return fmt.Errorf("failed to debit locked funds: %w", err)
+	}
+
+	return nil
+}
+
+// Credit credits the wallet (for sell proceeds)
+func (r *WalletRepository) Credit(ctx context.Context, walletID string, amount float64) error {
+	_, err := r.db.Exec(ctx, `
+		UPDATE wallets
+		SET balance = balance + $1, updated_at = NOW()
+		WHERE id = $2
+	`, amount, walletID)
+
+	if err != nil {
+		return fmt.Errorf("failed to credit wallet: %w", err)
+	}
+
+	return nil
+}

--- a/services/trading-service/internal/types/types.go
+++ b/services/trading-service/internal/types/types.go
@@ -1,0 +1,145 @@
+package types
+
+import "time"
+
+// PlaceOrderRequest is the request to place a new order
+type PlaceOrderRequest struct {
+	Symbol string  `json:"symbol"`
+	Side   string  `json:"side"`   // buy, sell
+	Amount float64 `json:"amount"` // Dollar amount for fractional shares
+	Qty    float64 `json:"qty"`    // Number of shares (alternative to amount)
+	Source string  `json:"source"` // web, mobile, ussd
+}
+
+// PlaceOrderResponse is the response after placing an order
+type PlaceOrderResponse struct {
+	OrderID       string  `json:"order_id"`
+	AlpacaOrderID string  `json:"alpaca_order_id"`
+	Symbol        string  `json:"symbol"`
+	Side          string  `json:"side"`
+	Amount        float64 `json:"amount"`
+	Status        string  `json:"status"`
+	Message       string  `json:"message"`
+}
+
+// CancelOrderResponse is the response after canceling an order
+type CancelOrderResponse struct {
+	OrderID string `json:"order_id"`
+	Status  string `json:"status"`
+	Message string `json:"message"`
+}
+
+// Order represents a trading order
+type Order struct {
+	ID             string     `json:"id"`
+	UserID         string     `json:"user_id"`
+	AlpacaOrderID  string     `json:"alpaca_order_id"`
+	Symbol         string     `json:"symbol"`
+	Side           string     `json:"side"`
+	Type           string     `json:"type"`
+	Amount         float64    `json:"amount"`
+	Qty            float64    `json:"qty"`
+	FilledQty      float64    `json:"filled_qty"`
+	FilledAvgPrice float64    `json:"filled_avg_price"`
+	Status         string     `json:"status"`
+	Source         string     `json:"source"`
+	FailedReason   *string    `json:"failed_reason,omitempty"`
+	FilledAt       *time.Time `json:"filled_at,omitempty"`
+	CanceledAt     *time.Time `json:"canceled_at,omitempty"`
+	CreatedAt      time.Time  `json:"created_at"`
+	UpdatedAt      time.Time  `json:"updated_at"`
+}
+
+// Holding represents a user's stock holding
+type Holding struct {
+	ID              string    `json:"id"`
+	UserID          string    `json:"user_id"`
+	Symbol          string    `json:"symbol"`
+	Qty             float64   `json:"qty"`
+	AvgEntryPrice   float64   `json:"avg_entry_price"`
+	CurrentPrice    float64   `json:"current_price"`
+	MarketValue     float64   `json:"market_value"`
+	UnrealizedPL    float64   `json:"unrealized_pl"`
+	UnrealizedPLPct float64   `json:"unrealized_pl_pct"`
+	CreatedAt       time.Time `json:"created_at"`
+	UpdatedAt       time.Time `json:"updated_at"`
+}
+
+// Portfolio represents a user's complete portfolio
+type Portfolio struct {
+	Holdings   []Holding `json:"holdings"`
+	TotalValue float64   `json:"total_value"`
+	TotalPL    float64   `json:"total_pl"`
+	TotalPLPct float64   `json:"total_pl_pct"`
+	CashUSD    float64   `json:"cash_usd"`
+}
+
+// User represents user info needed for trading
+type User struct {
+	ID            string  `json:"id"`
+	Phone         string  `json:"phone"`
+	IsActive      bool    `json:"is_active"`
+	IsKYCVerified bool    `json:"is_kyc_verified"`
+}
+
+// Wallet represents user wallet info
+type Wallet struct {
+	ID            string    `json:"id"`
+	UserID        string    `json:"user_id"`
+	Currency      string    `json:"currency"`
+	Balance       float64   `json:"balance"`
+	LockedBalance float64   `json:"locked_balance"`
+	CreatedAt     time.Time `json:"created_at"`
+	UpdatedAt     time.Time `json:"updated_at"`
+}
+
+// AvailableBalance returns the balance available for trading
+func (w *Wallet) AvailableBalance() float64 {
+	return w.Balance - w.LockedBalance
+}
+
+// AlpacaWebhookEvent represents an Alpaca trade update webhook
+type AlpacaWebhookEvent struct {
+	Event string            `json:"event"`
+	Order AlpacaOrderUpdate `json:"order"`
+}
+
+// AlpacaOrderUpdate represents order data from Alpaca webhook
+type AlpacaOrderUpdate struct {
+	ID             string     `json:"id"`
+	ClientOrderID  string     `json:"client_order_id"`
+	Symbol         string     `json:"symbol"`
+	Side           string     `json:"side"`
+	Type           string     `json:"type"`
+	Qty            string     `json:"qty"`
+	FilledQty      string     `json:"filled_qty"`
+	FilledAvgPrice string     `json:"filled_avg_price"`
+	Status         string     `json:"status"`
+	CreatedAt      time.Time  `json:"created_at"`
+	UpdatedAt      time.Time  `json:"updated_at"`
+	FilledAt       *time.Time `json:"filled_at"`
+	CanceledAt     *time.Time `json:"canceled_at"`
+	FailedAt       *time.Time `json:"failed_at"`
+}
+
+// QuoteResponse represents stock quote data
+type QuoteResponse struct {
+	Symbol    string  `json:"symbol"`
+	BidPrice  float64 `json:"bid_price"`
+	AskPrice  float64 `json:"ask_price"`
+	LastPrice float64 `json:"last_price"`
+}
+
+// SearchResponse represents stock search results
+type SearchResponse struct {
+	Assets []AssetInfo `json:"assets"`
+}
+
+// AssetInfo represents basic asset information
+type AssetInfo struct {
+	Symbol       string `json:"symbol"`
+	Name         string `json:"name"`
+	Exchange     string `json:"exchange"`
+	Tradable     bool   `json:"tradable"`
+	Fractionable bool   `json:"fractionable"`
+}

--- a/services/trading-service/main.go
+++ b/services/trading-service/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"net"
 	"os"
@@ -10,28 +11,135 @@ import (
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/middleware/recover"
 
+	"github.com/Rohianon/equishare-global-trading/pkg/alpaca"
+	"github.com/Rohianon/equishare-global-trading/pkg/config"
+	"github.com/Rohianon/equishare-global-trading/pkg/database"
+	"github.com/Rohianon/equishare-global-trading/pkg/events"
 	"github.com/Rohianon/equishare-global-trading/pkg/logger"
 	"github.com/Rohianon/equishare-global-trading/pkg/middleware"
+	"github.com/Rohianon/equishare-global-trading/services/trading-service/internal/handler"
+	"github.com/Rohianon/equishare-global-trading/services/trading-service/internal/repository"
 )
 
 func main() {
 	logger.Init("trading-service", "info", true)
 	logger.Info().Msg("Starting Trading Service")
 
-	app := fiber.New(fiber.Config{AppName: "EquiShare Trading Service"})
+	cfg, err := config.Load("config")
+	if err != nil {
+		logger.Warn().Err(err).Msg("Failed to load config, using defaults")
+	}
+
+	ctx := context.Background()
+
+	// Database connection
+	dbCfg := &database.Config{
+		Host:     getEnvOrDefault("DB_HOST", cfg.Database.Host),
+		Port:     cfg.Database.Port,
+		User:     getEnvOrDefault("DB_USER", cfg.Database.User),
+		Password: getEnvOrDefault("DB_PASSWORD", cfg.Database.Password),
+		Database: getEnvOrDefault("DB_NAME", cfg.Database.Database),
+		SSLMode:  cfg.Database.SSLMode,
+	}
+	if dbCfg.Port == 0 {
+		dbCfg.Port = 5432
+	}
+	if dbCfg.SSLMode == "" {
+		dbCfg.SSLMode = "disable"
+	}
+
+	db, err := database.NewPool(ctx, dbCfg)
+	if err != nil {
+		logger.Fatal().Err(err).Msg("Failed to connect to database")
+	}
+	defer db.Close()
+	logger.Info().Msg("Connected to database")
+
+	// Alpaca client
+	var alpacaClient alpaca.TradingClient
+	alpacaAPIKey := os.Getenv("ALPACA_API_KEY")
+	alpacaSecretKey := os.Getenv("ALPACA_SECRET_KEY")
+	alpacaPaper := os.Getenv("ALPACA_PAPER") != "false" // Default to paper trading
+
+	if alpacaAPIKey == "" {
+		logger.Warn().Msg("Using mock Alpaca client (no API key configured)")
+		alpacaClient = alpaca.NewMockClient()
+	} else {
+		alpacaClient = alpaca.NewClient(&alpaca.Config{
+			APIKey:    alpacaAPIKey,
+			SecretKey: alpacaSecretKey,
+			Paper:     alpacaPaper,
+		})
+		logger.Info().Bool("paper", alpacaPaper).Msg("Connected to Alpaca")
+	}
+
+	// Kafka publisher
+	var publisher events.Publisher
+	if brokers := cfg.Kafka.Brokers; len(brokers) > 0 && brokers[0] != "" {
+		publisher = events.NewKafkaPublisher(brokers)
+		defer publisher.Close()
+		logger.Info().Msg("Connected to Kafka")
+	} else {
+		logger.Warn().Msg("Kafka not configured, events will not be published")
+	}
+
+	// Repositories
+	userRepo := repository.NewUserRepository(db)
+	walletRepo := repository.NewWalletRepository(db)
+	orderRepo := repository.NewOrderRepository(db)
+	holdingRepo := repository.NewHoldingRepository(db)
+
+	// Handler
+	h := handler.New(userRepo, walletRepo, orderRepo, holdingRepo, alpacaClient, publisher)
+
+	// JWT secret
+	jwtSecret := getEnvOrDefault("JWT_SECRET", "dev-secret-change-in-production")
+
+	// Fiber app
+	app := fiber.New(fiber.Config{
+		AppName:      "EquiShare Trading Service",
+		ErrorHandler: errorHandler,
+	})
 	app.Use(recover.New())
 	app.Use(middleware.RequestID())
+	app.Use(middleware.Logger())
+	app.Use(middleware.SecurityHeaders())
 
+	// Health check
 	app.Get("/health", func(c *fiber.Ctx) error {
 		return c.JSON(fiber.Map{"status": "healthy", "service": "trading-service"})
 	})
 
+	// Webhook endpoint (no auth required)
+	app.Post("/webhooks/alpaca/orders", h.AlpacaWebhook)
+
+	// API routes (auth required)
+	api := app.Group("/api/v1", middleware.Auth(jwtSecret))
+
+	// Orders
+	orders := api.Group("/orders")
+	orders.Post("/", h.PlaceOrder)
+	orders.Get("/", h.ListOrders)
+	orders.Get("/:id", h.GetOrder)
+	orders.Delete("/:id", h.CancelOrder)
+
+	// Portfolio
+	api.Get("/portfolio", h.GetPortfolio)
+
+	// Market data
+	api.Get("/quotes/:symbol", h.GetQuote)
+	api.Get("/assets/search", h.SearchAssets)
+
+	// Start server
+	port := getEnvOrDefault("PORT", "8003")
 	go func() {
-		if err := app.Listen(":8003"); err != nil && !errors.Is(err, net.ErrClosed) {
+		if err := app.Listen(":" + port); err != nil && !errors.Is(err, net.ErrClosed) {
 			logger.Fatal().Err(err).Msg("Failed to start server")
 		}
 	}()
+	logger.Info().Str("port", port).Msg("Trading Service started")
 
+	// Graceful shutdown
 	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
 	<-quit
@@ -40,4 +148,26 @@ func main() {
 	if err := app.Shutdown(); err != nil {
 		logger.Error().Err(err).Msg("Error during shutdown")
 	}
+}
+
+func getEnvOrDefault(key, defaultVal string) string {
+	if val := os.Getenv(key); val != "" {
+		return val
+	}
+	return defaultVal
+}
+
+func errorHandler(c *fiber.Ctx, err error) error {
+	code := fiber.StatusInternalServerError
+	message := "Internal Server Error"
+
+	var e *fiber.Error
+	if errors.As(err, &e) {
+		code = e.Code
+		message = e.Message
+	}
+
+	return c.Status(code).JSON(fiber.Map{
+		"error": message,
+	})
 }


### PR DESCRIPTION
## Summary
- Adds complete Alpaca Trading API client package (`pkg/alpaca`)
- Implements full trading service with order lifecycle management
- Supports fractional shares via dollar-amount orders
- Includes mock client for development without API keys

## Changes

### pkg/alpaca
- `client.go` - HTTP client with API key authentication
- `orders.go` - Order creation, cancellation, listing, replacement
- `positions.go` - Holdings, assets, and market data (quotes)
- `interface.go` - TradingClient interface for both real and mock
- `mock.go` - Full mock implementation for testing
- `alpaca_test.go` - Comprehensive tests for mock client

### services/trading-service
- `internal/types/types.go` - Order, Holding, Portfolio types
- `internal/repository/` - Order, Holding, Wallet, User repos
- `internal/handler/handler.go` - HTTP handlers with full order flow
- `main.go` - Wired up with Alpaca, Kafka, and auth middleware

## API Endpoints
- `POST /api/v1/orders` - Place buy/sell order
- `GET /api/v1/orders` - List user orders
- `GET /api/v1/orders/:id` - Get order details
- `DELETE /api/v1/orders/:id` - Cancel order
- `GET /api/v1/portfolio` - Get holdings with P&L
- `GET /api/v1/quotes/:symbol` - Get stock quote
- `GET /api/v1/assets/search?q=` - Search assets
- `POST /webhooks/alpaca/orders` - Order update webhook

## Test plan
- [x] Unit tests for Alpaca mock client
- [ ] Integration tests with paper trading sandbox
- [ ] Test order placement and fill flow
- [ ] Test cancel order flow
- [ ] Test portfolio with live quotes

Closes #21