### PR TITLE
feat(events): establish Kafka event bus conventions and standards

### DIFF
--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -3,46 +3,297 @@ package events
 import (
 	"context"
 	"time"
+
+	"github.com/google/uuid"
 )
 
+// Event represents the standard event envelope for all Kafka messages.
+// All events published to Kafka MUST use this envelope format.
+//
+// Topic Naming Convention:
+//
+//	equishare.<domain>.<action>
+//	Examples: equishare.orders.created, equishare.payments.completed
+//
+// Event Versioning:
+//   - Event types include version: "order.created.v1"
+//   - Payload structure is versioned independently
+//   - Breaking changes require new version (v2, v3, etc.)
+//   - Consumers should handle unknown fields gracefully
 type Event struct {
-	ID       string            `json:"id"`
-	Type     string            `json:"type"`
-	Source   string            `json:"source"`
-	Time     time.Time         `json:"time"`
-	Data     any               `json:"data"`
+	// EventID is a unique identifier for this event instance
+	EventID string `json:"event_id"`
+
+	// EventType describes the event in format: <domain>.<action>.v<version>
+	// Examples: "order.created.v1", "payment.completed.v1"
+	EventType string `json:"event_type"`
+
+	// OccurredAt is when the event actually happened (not when it was published)
+	OccurredAt time.Time `json:"occurred_at"`
+
+	// CorrelationID links related events across services (e.g., same user request)
+	CorrelationID string `json:"correlation_id,omitempty"`
+
+	// Source identifies the service that produced this event
+	Source string `json:"source"`
+
+	// Payload contains the event-specific data
+	Payload any `json:"payload"`
+
+	// Metadata contains optional key-value pairs for tracing, debugging, etc.
 	Metadata map[string]string `json:"metadata,omitempty"`
 }
 
+// NewEvent creates a new event with auto-generated ID and timestamp
+func NewEvent(eventType, source string, payload any) *Event {
+	return &Event{
+		EventID:    uuid.New().String(),
+		EventType:  eventType,
+		OccurredAt: time.Now().UTC(),
+		Source:     source,
+		Payload:    payload,
+		Metadata:   make(map[string]string),
+	}
+}
+
+// WithCorrelationID sets the correlation ID for request tracing
+func (e *Event) WithCorrelationID(id string) *Event {
+	e.CorrelationID = id
+	return e
+}
+
+// WithMetadata adds a metadata key-value pair
+func (e *Event) WithMetadata(key, value string) *Event {
+	if e.Metadata == nil {
+		e.Metadata = make(map[string]string)
+	}
+	e.Metadata[key] = value
+	return e
+}
+
+// =============================================================================
+// Topic Registry
+// =============================================================================
+// All Kafka topics used in the system are defined here.
+// Topic naming: equishare.<domain>.<action>
+//
+// Adding a new topic:
+// 1. Add the constant below with documentation
+// 2. Document the payload structure
+// 3. Update the Topics slice
+// =============================================================================
+
 const (
-	TopicOrderCreated   = "equishare.orders.created"
-	TopicOrderUpdated   = "equishare.orders.updated"
-	TopicOrderFilled    = "equishare.orders.filled"
+	// Order Domain
+	// Published by: trading-service
+	// Consumed by: portfolio-service, notification-service
+
+	// TopicOrderCreated is published when a new order is submitted
+	// Payload: OrderCreatedPayload
+	TopicOrderCreated = "equishare.orders.created"
+
+	// TopicOrderFilled is published when an order is completely filled
+	// Payload: OrderFilledPayload
+	TopicOrderFilled = "equishare.orders.filled"
+
+	// TopicOrderPartialFill is published when an order is partially filled
+	// Payload: OrderPartialFillPayload
+	TopicOrderPartialFill = "equishare.orders.partial_fill"
+
+	// TopicOrderCancelled is published when an order is cancelled
+	// Payload: OrderCancelledPayload
 	TopicOrderCancelled = "equishare.orders.cancelled"
 
-	TopicPaymentInitiated = "equishare.payments.initiated"
-	TopicPaymentCompleted = "equishare.payments.completed"
-	TopicPaymentFailed    = "equishare.payments.failed"
+	// TopicOrderRejected is published when an order is rejected by the exchange
+	// Payload: OrderRejectedPayload
+	TopicOrderRejected = "equishare.orders.rejected"
 
+	// Payment Domain
+	// Published by: payment-service
+	// Consumed by: notification-service, trading-service
+
+	// TopicPaymentInitiated is published when a deposit/payment is initiated
+	// Payload: PaymentInitiatedPayload
+	TopicPaymentInitiated = "equishare.payments.initiated"
+
+	// TopicPaymentCompleted is published when a payment succeeds
+	// Payload: PaymentCompletedPayload
+	TopicPaymentCompleted = "equishare.payments.completed"
+
+	// TopicPaymentFailed is published when a payment fails
+	// Payload: PaymentFailedPayload
+	TopicPaymentFailed = "equishare.payments.failed"
+
+	// Withdrawal Domain
+	// Published by: payment-service
+	// Consumed by: notification-service
+
+	// TopicWithdrawalInitiated is published when a withdrawal is requested
+	// Payload: WithdrawalInitiatedPayload
 	TopicWithdrawalInitiated = "equishare.withdrawals.initiated"
+
+	// TopicWithdrawalCompleted is published when a withdrawal succeeds
+	// Payload: WithdrawalCompletedPayload
 	TopicWithdrawalCompleted = "equishare.withdrawals.completed"
 
+	// TopicWithdrawalFailed is published when a withdrawal fails
+	// Payload: WithdrawalFailedPayload
+	TopicWithdrawalFailed = "equishare.withdrawals.failed"
+
+	// KYC Domain
+	// Published by: user-service
+	// Consumed by: notification-service, trading-service
+
+	// TopicKYCSubmitted is published when KYC documents are submitted
+	// Payload: KYCSubmittedPayload
 	TopicKYCSubmitted = "equishare.kyc.submitted"
-	TopicKYCVerified  = "equishare.kyc.verified"
-	TopicKYCRejected  = "equishare.kyc.rejected"
 
-	TopicPriceUpdate    = "equishare.prices.realtime"
-	TopicAlertTriggered = "equishare.alerts.triggered"
+	// TopicKYCVerified is published when KYC is approved
+	// Payload: KYCVerifiedPayload
+	TopicKYCVerified = "equishare.kyc.verified"
 
+	// TopicKYCRejected is published when KYC is rejected
+	// Payload: KYCRejectedPayload
+	TopicKYCRejected = "equishare.kyc.rejected"
+
+	// User Domain
+	// Published by: auth-service, user-service
+	// Consumed by: notification-service
+
+	// TopicUserRegistered is published when a new user registers
+	// Payload: UserRegisteredPayload
+	TopicUserRegistered = "equishare.users.registered"
+
+	// TopicUserVerified is published when a user verifies their phone/email
+	// Payload: UserVerifiedPayload
+	TopicUserVerified = "equishare.users.verified"
+
+	// Market Data Domain
+	// Published by: market-data-service
+	// Consumed by: trading-service, portfolio-service
+
+	// TopicPriceUpdate is published for real-time price updates
+	// Payload: PriceUpdatePayload
+	TopicPriceUpdate = "equishare.prices.update"
+
+	// TopicMarketOpen is published when market opens
+	// Payload: MarketStatusPayload
+	TopicMarketOpen = "equishare.market.open"
+
+	// TopicMarketClose is published when market closes
+	// Payload: MarketStatusPayload
+	TopicMarketClose = "equishare.market.close"
+
+	// Notification Domain
+	// Published by: various services
+	// Consumed by: notification-service
+
+	// TopicNotificationSend is published to trigger notifications
+	// Payload: NotificationPayload
 	TopicNotificationSend = "equishare.notifications.send"
+
+	// Alert Domain
+	// Published by: portfolio-service
+	// Consumed by: notification-service
+
+	// TopicAlertTriggered is published when a price alert is triggered
+	// Payload: AlertTriggeredPayload
+	TopicAlertTriggered = "equishare.alerts.triggered"
 )
 
+// AllTopics returns all registered topics for admin/setup purposes
+var AllTopics = []string{
+	TopicOrderCreated,
+	TopicOrderFilled,
+	TopicOrderPartialFill,
+	TopicOrderCancelled,
+	TopicOrderRejected,
+	TopicPaymentInitiated,
+	TopicPaymentCompleted,
+	TopicPaymentFailed,
+	TopicWithdrawalInitiated,
+	TopicWithdrawalCompleted,
+	TopicWithdrawalFailed,
+	TopicKYCSubmitted,
+	TopicKYCVerified,
+	TopicKYCRejected,
+	TopicUserRegistered,
+	TopicUserVerified,
+	TopicPriceUpdate,
+	TopicMarketOpen,
+	TopicMarketClose,
+	TopicNotificationSend,
+	TopicAlertTriggered,
+}
+
+// =============================================================================
+// Event Types (versioned)
+// =============================================================================
+
+const (
+	// Order events
+	EventTypeOrderCreated     = "order.created.v1"
+	EventTypeOrderFilled      = "order.filled.v1"
+	EventTypeOrderPartialFill = "order.partial_fill.v1"
+	EventTypeOrderCancelled   = "order.cancelled.v1"
+	EventTypeOrderRejected    = "order.rejected.v1"
+
+	// Payment events
+	EventTypePaymentInitiated = "payment.initiated.v1"
+	EventTypePaymentCompleted = "payment.completed.v1"
+	EventTypePaymentFailed    = "payment.failed.v1"
+
+	// Withdrawal events
+	EventTypeWithdrawalInitiated = "withdrawal.initiated.v1"
+	EventTypeWithdrawalCompleted = "withdrawal.completed.v1"
+	EventTypeWithdrawalFailed    = "withdrawal.failed.v1"
+
+	// KYC events
+	EventTypeKYCSubmitted = "kyc.submitted.v1"
+	EventTypeKYCVerified  = "kyc.verified.v1"
+	EventTypeKYCRejected  = "kyc.rejected.v1"
+
+	// User events
+	EventTypeUserRegistered = "user.registered.v1"
+	EventTypeUserVerified   = "user.verified.v1"
+
+	// Market events
+	EventTypePriceUpdate = "price.update.v1"
+	EventTypeMarketOpen  = "market.open.v1"
+	EventTypeMarketClose = "market.close.v1"
+
+	// Notification events
+	EventTypeNotificationSend = "notification.send.v1"
+
+	// Alert events
+	EventTypeAlertTriggered = "alert.triggered.v1"
+)
+
+// =============================================================================
+// Interfaces
+// =============================================================================
+
+// Publisher publishes events to Kafka topics
 type Publisher interface {
+	// Publish sends an event to the specified topic
 	Publish(ctx context.Context, topic string, event *Event) error
+
+	// Close closes the publisher and releases resources
 	Close() error
 }
 
+// Subscriber consumes events from Kafka topics
 type Subscriber interface {
+	// Subscribe registers a handler for events on the specified topic
 	Subscribe(ctx context.Context, topic string, handler func(*Event) error) error
+
+	// Close closes the subscriber and releases resources
 	Close() error
 }
+
+// =============================================================================
+// Legacy compatibility - these will be removed in v2
+// =============================================================================
+
+// Deprecated: Use TopicOrderFilled instead
+var TopicOrderUpdated = TopicOrderFilled

--- a/pkg/events/events_test.go
+++ b/pkg/events/events_test.go
@@ -11,18 +11,24 @@ func TestEventTopics(t *testing.T) {
 		topic string
 	}{
 		{"TopicOrderCreated", TopicOrderCreated},
-		{"TopicOrderUpdated", TopicOrderUpdated},
 		{"TopicOrderFilled", TopicOrderFilled},
+		{"TopicOrderPartialFill", TopicOrderPartialFill},
 		{"TopicOrderCancelled", TopicOrderCancelled},
+		{"TopicOrderRejected", TopicOrderRejected},
 		{"TopicPaymentInitiated", TopicPaymentInitiated},
 		{"TopicPaymentCompleted", TopicPaymentCompleted},
 		{"TopicPaymentFailed", TopicPaymentFailed},
 		{"TopicWithdrawalInitiated", TopicWithdrawalInitiated},
 		{"TopicWithdrawalCompleted", TopicWithdrawalCompleted},
+		{"TopicWithdrawalFailed", TopicWithdrawalFailed},
 		{"TopicKYCSubmitted", TopicKYCSubmitted},
 		{"TopicKYCVerified", TopicKYCVerified},
 		{"TopicKYCRejected", TopicKYCRejected},
+		{"TopicUserRegistered", TopicUserRegistered},
+		{"TopicUserVerified", TopicUserVerified},
 		{"TopicPriceUpdate", TopicPriceUpdate},
+		{"TopicMarketOpen", TopicMarketOpen},
+		{"TopicMarketClose", TopicMarketClose},
 		{"TopicAlertTriggered", TopicAlertTriggered},
 		{"TopicNotificationSend", TopicNotificationSend},
 	}
@@ -32,8 +38,100 @@ func TestEventTopics(t *testing.T) {
 			if tt.topic == "" {
 				t.Errorf("%s should not be empty", tt.name)
 			}
-			if len(tt.topic) < 10 {
-				t.Errorf("%s topic name too short: %s", tt.name, tt.topic)
+			// All topics should start with "equishare."
+			if len(tt.topic) < 10 || tt.topic[:10] != "equishare." {
+				t.Errorf("%s topic should start with 'equishare.': %s", tt.name, tt.topic)
+			}
+		})
+	}
+}
+
+func TestAllTopics(t *testing.T) {
+	if len(AllTopics) == 0 {
+		t.Error("AllTopics should not be empty")
+	}
+
+	// Verify all topics in AllTopics are valid
+	for _, topic := range AllTopics {
+		if topic == "" {
+			t.Error("AllTopics contains empty topic")
+		}
+	}
+}
+
+func TestNewEvent(t *testing.T) {
+	payload := OrderCreatedPayload{
+		OrderID: "order-123",
+		UserID:  "user-456",
+		Symbol:  "AAPL",
+		Side:    "buy",
+		Amount:  100.00,
+	}
+
+	event := NewEvent(EventTypeOrderCreated, "trading-service", payload)
+
+	if event.EventID == "" {
+		t.Error("EventID should be auto-generated")
+	}
+	if event.EventType != EventTypeOrderCreated {
+		t.Errorf("EventType = %v, want %v", event.EventType, EventTypeOrderCreated)
+	}
+	if event.Source != "trading-service" {
+		t.Errorf("Source = %v, want trading-service", event.Source)
+	}
+	if event.OccurredAt.IsZero() {
+		t.Error("OccurredAt should be auto-set")
+	}
+	if event.Metadata == nil {
+		t.Error("Metadata should be initialized")
+	}
+}
+
+func TestEventWithCorrelationID(t *testing.T) {
+	event := NewEvent(EventTypeOrderCreated, "trading-service", nil)
+	event.WithCorrelationID("corr-123")
+
+	if event.CorrelationID != "corr-123" {
+		t.Errorf("CorrelationID = %v, want corr-123", event.CorrelationID)
+	}
+}
+
+func TestEventWithMetadata(t *testing.T) {
+	event := NewEvent(EventTypeOrderCreated, "trading-service", nil)
+	event.WithMetadata("trace_id", "trace-123").
+		WithMetadata("request_id", "req-456")
+
+	if event.Metadata["trace_id"] != "trace-123" {
+		t.Errorf("Metadata[trace_id] = %v, want trace-123", event.Metadata["trace_id"])
+	}
+	if event.Metadata["request_id"] != "req-456" {
+		t.Errorf("Metadata[request_id] = %v, want req-456", event.Metadata["request_id"])
+	}
+}
+
+func TestEventTypes(t *testing.T) {
+	types := []struct {
+		name      string
+		eventType string
+	}{
+		{"EventTypeOrderCreated", EventTypeOrderCreated},
+		{"EventTypeOrderFilled", EventTypeOrderFilled},
+		{"EventTypePaymentInitiated", EventTypePaymentInitiated},
+		{"EventTypePaymentCompleted", EventTypePaymentCompleted},
+		{"EventTypeKYCVerified", EventTypeKYCVerified},
+		{"EventTypeUserRegistered", EventTypeUserRegistered},
+		{"EventTypePriceUpdate", EventTypePriceUpdate},
+	}
+
+	for _, tt := range types {
+		t.Run(tt.name, func(t *testing.T) {
+			// All event types should end with version (v1, v2, etc.)
+			if len(tt.eventType) < 3 {
+				t.Errorf("%s is too short", tt.eventType)
+			}
+			lastThree := tt.eventType[len(tt.eventType)-3:]
+			if lastThree[0] != '.' || lastThree[1] != 'v' {
+				t.Errorf("%s should end with version (e.g., .v1): %s", tt.name, tt.eventType)
 			}
 		})
 	}
@@ -41,11 +139,12 @@ func TestEventTopics(t *testing.T) {
 
 func TestEventStruct(t *testing.T) {
 	event := Event{
-		ID:     "test-id",
-		Type:   "order.created",
-		Source: "trading-service",
-		Time:   time.Now(),
-		Data: map[string]any{
+		EventID:       "test-id",
+		EventType:     "order.created.v1",
+		Source:        "trading-service",
+		OccurredAt:    time.Now(),
+		CorrelationID: "corr-123",
+		Payload: map[string]any{
 			"order_id": "123",
 			"amount":   100.50,
 		},
@@ -54,16 +153,58 @@ func TestEventStruct(t *testing.T) {
 		},
 	}
 
-	if event.ID != "test-id" {
-		t.Errorf("Event.ID = %v, want test-id", event.ID)
+	if event.EventID != "test-id" {
+		t.Errorf("Event.EventID = %v, want test-id", event.EventID)
 	}
-	if event.Type != "order.created" {
-		t.Errorf("Event.Type = %v, want order.created", event.Type)
+	if event.EventType != "order.created.v1" {
+		t.Errorf("Event.EventType = %v, want order.created.v1", event.EventType)
 	}
 	if event.Source != "trading-service" {
 		t.Errorf("Event.Source = %v, want trading-service", event.Source)
 	}
+	if event.CorrelationID != "corr-123" {
+		t.Errorf("Event.CorrelationID = %v, want corr-123", event.CorrelationID)
+	}
 	if event.Metadata["trace_id"] != "abc-123" {
 		t.Errorf("Event.Metadata[trace_id] = %v, want abc-123", event.Metadata["trace_id"])
+	}
+}
+
+func TestLegacyCompatibility(t *testing.T) {
+	// TopicOrderUpdated should still work (deprecated alias)
+	if TopicOrderUpdated != TopicOrderFilled {
+		t.Errorf("TopicOrderUpdated should alias to TopicOrderFilled")
+	}
+}
+
+func TestPayloadStructs(t *testing.T) {
+	// Test that payload structs can be instantiated
+	_ = OrderCreatedPayload{
+		OrderID: "order-1",
+		UserID:  "user-1",
+		Symbol:  "AAPL",
+		Side:    "buy",
+		Amount:  100.00,
+	}
+
+	_ = PaymentCompletedPayload{
+		UserID:        "user-1",
+		WalletID:      "wallet-1",
+		TransactionID: "tx-1",
+		Amount:        500.00,
+		Currency:      "KES",
+		Provider:      "mpesa",
+		ProviderRef:   "ABC123",
+		CompletedAt:   time.Now(),
+		NewBalance:    1500.00,
+	}
+
+	_ = PriceUpdatePayload{
+		Symbol:    "AAPL",
+		BidPrice:  149.50,
+		AskPrice:  150.50,
+		LastPrice: 150.00,
+		Volume:    1000000,
+		Timestamp: time.Now(),
 	}
 }

--- a/pkg/events/payloads.go
+++ b/pkg/events/payloads.go
@@ -1,0 +1,210 @@
+package events
+
+import "time"
+
+// =============================================================================
+// Event Payload Definitions
+// =============================================================================
+// Each event type has a corresponding payload struct defined here.
+// When adding new events, define the payload structure here first.
+//
+// Guidelines:
+// - Use primitive types where possible (string, int, float64, bool)
+// - Use time.Time for timestamps
+// - Use pointers for optional fields
+// - Include user_id in all user-related payloads
+// - Include correlation fields to link related entities
+// =============================================================================
+
+// OrderCreatedPayload is the payload for order.created.v1 events
+type OrderCreatedPayload struct {
+	OrderID       string  `json:"order_id"`
+	UserID        string  `json:"user_id"`
+	Symbol        string  `json:"symbol"`
+	Side          string  `json:"side"` // buy, sell
+	Type          string  `json:"type"` // market, limit
+	Amount        float64 `json:"amount,omitempty"`
+	Qty           float64 `json:"qty,omitempty"`
+	LimitPrice    float64 `json:"limit_price,omitempty"`
+	Source        string  `json:"source"` // web, mobile, ussd, api
+	AlpacaOrderID string  `json:"alpaca_order_id,omitempty"`
+}
+
+// OrderFilledPayload is the payload for order.filled.v1 events
+type OrderFilledPayload struct {
+	OrderID        string    `json:"order_id"`
+	UserID         string    `json:"user_id"`
+	Symbol         string    `json:"symbol"`
+	Side           string    `json:"side"`
+	FilledQty      float64   `json:"filled_qty"`
+	FilledAvgPrice float64   `json:"filled_avg_price"`
+	TotalValue     float64   `json:"total_value"`
+	FilledAt       time.Time `json:"filled_at"`
+}
+
+// OrderPartialFillPayload is the payload for order.partial_fill.v1 events
+type OrderPartialFillPayload struct {
+	OrderID        string  `json:"order_id"`
+	UserID         string  `json:"user_id"`
+	Symbol         string  `json:"symbol"`
+	FilledQty      float64 `json:"filled_qty"`
+	RemainingQty   float64 `json:"remaining_qty"`
+	FilledAvgPrice float64 `json:"filled_avg_price"`
+}
+
+// OrderCancelledPayload is the payload for order.cancelled.v1 events
+type OrderCancelledPayload struct {
+	OrderID      string    `json:"order_id"`
+	UserID       string    `json:"user_id"`
+	Symbol       string    `json:"symbol"`
+	CancelledAt  time.Time `json:"cancelled_at"`
+	CancelReason string    `json:"cancel_reason,omitempty"`
+}
+
+// OrderRejectedPayload is the payload for order.rejected.v1 events
+type OrderRejectedPayload struct {
+	OrderID      string `json:"order_id"`
+	UserID       string `json:"user_id"`
+	Symbol       string `json:"symbol"`
+	RejectReason string `json:"reject_reason"`
+}
+
+// PaymentInitiatedPayload is the payload for payment.initiated.v1 events
+type PaymentInitiatedPayload struct {
+	UserID            string  `json:"user_id"`
+	WalletID          string  `json:"wallet_id"`
+	Amount            float64 `json:"amount"`
+	Currency          string  `json:"currency"`
+	Provider          string  `json:"provider"` // mpesa, card, bank
+	CheckoutRequestID string  `json:"checkout_request_id,omitempty"`
+}
+
+// PaymentCompletedPayload is the payload for payment.completed.v1 events
+type PaymentCompletedPayload struct {
+	UserID        string    `json:"user_id"`
+	WalletID      string    `json:"wallet_id"`
+	TransactionID string    `json:"transaction_id"`
+	Amount        float64   `json:"amount"`
+	Currency      string    `json:"currency"`
+	Provider      string    `json:"provider"`
+	ProviderRef   string    `json:"provider_ref"` // e.g., M-Pesa receipt number
+	CompletedAt   time.Time `json:"completed_at"`
+	NewBalance    float64   `json:"new_balance"`
+}
+
+// PaymentFailedPayload is the payload for payment.failed.v1 events
+type PaymentFailedPayload struct {
+	UserID       string `json:"user_id"`
+	WalletID     string `json:"wallet_id"`
+	Amount       float64 `json:"amount"`
+	Currency     string `json:"currency"`
+	Provider     string `json:"provider"`
+	FailureCode  string `json:"failure_code"`
+	FailureReason string `json:"failure_reason"`
+}
+
+// WithdrawalInitiatedPayload is the payload for withdrawal.initiated.v1 events
+type WithdrawalInitiatedPayload struct {
+	WithdrawalID string  `json:"withdrawal_id"`
+	UserID       string  `json:"user_id"`
+	WalletID     string  `json:"wallet_id"`
+	Amount       float64 `json:"amount"`
+	Currency     string  `json:"currency"`
+	Destination  string  `json:"destination"` // phone number or bank account
+	Provider     string  `json:"provider"`    // mpesa, bank
+}
+
+// WithdrawalCompletedPayload is the payload for withdrawal.completed.v1 events
+type WithdrawalCompletedPayload struct {
+	WithdrawalID string    `json:"withdrawal_id"`
+	UserID       string    `json:"user_id"`
+	Amount       float64   `json:"amount"`
+	Currency     string    `json:"currency"`
+	ProviderRef  string    `json:"provider_ref"`
+	CompletedAt  time.Time `json:"completed_at"`
+}
+
+// WithdrawalFailedPayload is the payload for withdrawal.failed.v1 events
+type WithdrawalFailedPayload struct {
+	WithdrawalID  string `json:"withdrawal_id"`
+	UserID        string `json:"user_id"`
+	Amount        float64 `json:"amount"`
+	Currency      string `json:"currency"`
+	FailureCode   string `json:"failure_code"`
+	FailureReason string `json:"failure_reason"`
+}
+
+// KYCSubmittedPayload is the payload for kyc.submitted.v1 events
+type KYCSubmittedPayload struct {
+	UserID       string   `json:"user_id"`
+	DocumentType string   `json:"document_type"` // national_id, passport, drivers_license
+	Documents    []string `json:"documents"`     // document IDs/URLs
+	SubmittedAt  time.Time `json:"submitted_at"`
+}
+
+// KYCVerifiedPayload is the payload for kyc.verified.v1 events
+type KYCVerifiedPayload struct {
+	UserID     string    `json:"user_id"`
+	VerifiedAt time.Time `json:"verified_at"`
+	VerifiedBy string    `json:"verified_by,omitempty"` // manual or provider name
+}
+
+// KYCRejectedPayload is the payload for kyc.rejected.v1 events
+type KYCRejectedPayload struct {
+	UserID       string `json:"user_id"`
+	RejectReason string `json:"reject_reason"`
+	CanRetry     bool   `json:"can_retry"`
+}
+
+// UserRegisteredPayload is the payload for user.registered.v1 events
+type UserRegisteredPayload struct {
+	UserID       string    `json:"user_id"`
+	Phone        string    `json:"phone"`
+	Email        string    `json:"email,omitempty"`
+	RegisteredAt time.Time `json:"registered_at"`
+	Source       string    `json:"source"` // app, ussd, web
+}
+
+// UserVerifiedPayload is the payload for user.verified.v1 events
+type UserVerifiedPayload struct {
+	UserID       string    `json:"user_id"`
+	VerifiedType string    `json:"verified_type"` // phone, email
+	VerifiedAt   time.Time `json:"verified_at"`
+}
+
+// PriceUpdatePayload is the payload for price.update.v1 events
+type PriceUpdatePayload struct {
+	Symbol    string    `json:"symbol"`
+	BidPrice  float64   `json:"bid_price"`
+	AskPrice  float64   `json:"ask_price"`
+	LastPrice float64   `json:"last_price"`
+	Volume    int64     `json:"volume"`
+	Timestamp time.Time `json:"timestamp"`
+}
+
+// MarketStatusPayload is the payload for market.open.v1 and market.close.v1 events
+type MarketStatusPayload struct {
+	Exchange  string    `json:"exchange"`
+	Status    string    `json:"status"` // open, close, halt
+	Timestamp time.Time `json:"timestamp"`
+}
+
+// NotificationPayload is the payload for notification.send.v1 events
+type NotificationPayload struct {
+	UserID       string            `json:"user_id"`
+	Channel      string            `json:"channel"`  // sms, push, email
+	Template     string            `json:"template"` // template name
+	TemplateData map[string]string `json:"template_data"`
+	Priority     string            `json:"priority,omitempty"` // high, normal, low
+}
+
+// AlertTriggeredPayload is the payload for alert.triggered.v1 events
+type AlertTriggeredPayload struct {
+	AlertID      string    `json:"alert_id"`
+	UserID       string    `json:"user_id"`
+	Symbol       string    `json:"symbol"`
+	AlertType    string    `json:"alert_type"`    // price_above, price_below, percent_change
+	TargetValue  float64   `json:"target_value"`
+	CurrentValue float64   `json:"current_value"`
+	TriggeredAt  time.Time `json:"triggered_at"`
+}


### PR DESCRIPTION
## Summary
- Adds standardized Event envelope with EventID, EventType, OccurredAt, CorrelationID, Source, Payload, and Metadata fields
- Defines 21 Kafka topics with `equishare.<domain>.<action>` naming convention
- Creates versioned event types (e.g., `order.created.v1`) for schema evolution
- Adds typed payload structs for all event types (OrderCreatedPayload, PaymentCompletedPayload, etc.)
- Updates KafkaPublisher/Subscriber with OpenTelemetry trace context propagation
- Implements kafkaHeaderCarrier for W3C trace context in Kafka headers

## Test plan
- [x] All existing tests pass
- [x] New tests for Event creation and topics
- [x] Tests for kafkaHeaderCarrier Get/Set/Keys operations
- [x] Interface compliance tests for KafkaPublisher/KafkaSubscriber

Closes #23