### PR TITLE
feat(auth): implement session management with JWT refresh rotation

### DIFF
--- a/pkg/auth/jwt.go
+++ b/pkg/auth/jwt.go
@@ -1,34 +1,53 @@
 package auth
 
 import (
+	"context"
 	"fmt"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
 )
 
+// =============================================================================
+// JWT Token Management
+// =============================================================================
+// This package provides JWT token generation and validation with support for:
+// - Access tokens (short-lived, for API authentication)
+// - Refresh tokens (long-lived, for obtaining new access tokens)
+// - Session tracking (refresh tokens are bound to sessions for revocation)
+// =============================================================================
+
+// Config holds JWT configuration
 type Config struct {
-	Secret           string
-	AccessTokenTTL   time.Duration
-	RefreshTokenTTL  time.Duration
+	Secret          string
+	AccessTokenTTL  time.Duration
+	RefreshTokenTTL time.Duration
 }
 
+// Claims represents JWT token claims
 type Claims struct {
-	UserID string `json:"user_id"`
-	Phone  string `json:"phone"`
+	UserID    string `json:"user_id"`
+	Phone     string `json:"phone"`
+	SessionID string `json:"session_id,omitempty"` // Only in refresh tokens
+	TokenType string `json:"token_type"`           // "access" or "refresh"
 	jwt.RegisteredClaims
 }
 
+// TokenPair contains access and refresh tokens
 type TokenPair struct {
-	AccessToken  string
-	RefreshToken string
-	ExpiresIn    int
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	ExpiresIn    int    `json:"expires_in"` // Access token TTL in seconds
+	SessionID    string `json:"-"`          // Internal use for session tracking
 }
 
+// JWTManager handles JWT operations
 type JWTManager struct {
-	config *Config
+	config       *Config
+	sessionStore SessionStore
 }
 
+// NewJWTManager creates a new JWT manager
 func NewJWTManager(cfg *Config) *JWTManager {
 	if cfg.AccessTokenTTL == 0 {
 		cfg.AccessTokenTTL = 15 * time.Minute
@@ -39,38 +58,135 @@ func NewJWTManager(cfg *Config) *JWTManager {
 	return &JWTManager{config: cfg}
 }
 
+// WithSessionStore adds session store for token revocation support
+func (m *JWTManager) WithSessionStore(store SessionStore) *JWTManager {
+	m.sessionStore = store
+	return m
+}
+
+// GenerateTokenPair creates a new access/refresh token pair
 func (m *JWTManager) GenerateTokenPair(userID, phone string) (*TokenPair, error) {
-	accessToken, err := m.generateToken(userID, phone, m.config.AccessTokenTTL)
+	return m.GenerateTokenPairWithSession(context.Background(), userID, phone, "", "")
+}
+
+// GenerateTokenPairWithSession creates tokens with session tracking
+func (m *JWTManager) GenerateTokenPairWithSession(ctx context.Context, userID, phone, userAgent, ipAddress string) (*TokenPair, error) {
+	// Generate session ID for tracking
+	sessionID, err := GenerateSessionID()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate session ID: %w", err)
+	}
+
+	// Generate access token (no session ID, short-lived)
+	accessToken, err := m.generateAccessToken(userID, phone)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate access token: %w", err)
 	}
 
-	refreshToken, err := m.generateToken(userID, phone, m.config.RefreshTokenTTL)
+	// Generate refresh token (with session ID, long-lived)
+	refreshToken, err := m.generateRefreshToken(userID, phone, sessionID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate refresh token: %w", err)
+	}
+
+	// Store session if store is configured
+	if m.sessionStore != nil {
+		session := &Session{
+			ID:        sessionID,
+			UserID:    userID,
+			TokenHash: HashToken(refreshToken),
+			CreatedAt: time.Now(),
+			ExpiresAt: time.Now().Add(m.config.RefreshTokenTTL),
+			UserAgent: userAgent,
+			IPAddress: ipAddress,
+		}
+		if err := m.sessionStore.Create(ctx, session); err != nil {
+			return nil, fmt.Errorf("failed to create session: %w", err)
+		}
 	}
 
 	return &TokenPair{
 		AccessToken:  accessToken,
 		RefreshToken: refreshToken,
 		ExpiresIn:    int(m.config.AccessTokenTTL.Seconds()),
+		SessionID:    sessionID,
 	}, nil
 }
 
-func (m *JWTManager) generateToken(userID, phone string, ttl time.Duration) (string, error) {
-	claims := &Claims{
-		UserID: userID,
-		Phone:  phone,
-		RegisteredClaims: jwt.RegisteredClaims{
-			ExpiresAt: jwt.NewNumericDate(time.Now().Add(ttl)),
-			IssuedAt:  jwt.NewNumericDate(time.Now()),
-		},
+// RefreshTokens validates a refresh token and issues new tokens
+func (m *JWTManager) RefreshTokens(ctx context.Context, refreshToken string) (*TokenPair, error) {
+	// Validate the refresh token
+	claims, err := m.ValidateRefreshToken(refreshToken)
+	if err != nil {
+		return nil, err
 	}
 
-	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
-	return token.SignedString([]byte(m.config.Secret))
+	// If session store is configured, validate and rotate session
+	if m.sessionStore != nil {
+		tokenHash := HashToken(refreshToken)
+		session, err := m.sessionStore.Validate(ctx, claims.SessionID, tokenHash)
+		if err != nil {
+			return nil, fmt.Errorf("failed to validate session: %w", err)
+		}
+		if session == nil {
+			return nil, fmt.Errorf("session not found or token already rotated")
+		}
+
+		// Generate new refresh token for rotation
+		newRefreshToken, err := m.generateRefreshToken(claims.UserID, claims.Phone, claims.SessionID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate new refresh token: %w", err)
+		}
+
+		// Rotate the session with new token hash
+		newExpiry := time.Now().Add(m.config.RefreshTokenTTL)
+		if err := m.sessionStore.Rotate(ctx, claims.SessionID, HashToken(newRefreshToken), newExpiry); err != nil {
+			return nil, fmt.Errorf("failed to rotate session: %w", err)
+		}
+
+		// Generate new access token
+		accessToken, err := m.generateAccessToken(claims.UserID, claims.Phone)
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate access token: %w", err)
+		}
+
+		return &TokenPair{
+			AccessToken:  accessToken,
+			RefreshToken: newRefreshToken,
+			ExpiresIn:    int(m.config.AccessTokenTTL.Seconds()),
+			SessionID:    claims.SessionID,
+		}, nil
+	}
+
+	// Without session store, just generate new tokens (less secure)
+	return m.GenerateTokenPair(claims.UserID, claims.Phone)
 }
 
+// RevokeSession invalidates a session (logout)
+func (m *JWTManager) RevokeSession(ctx context.Context, sessionID string) error {
+	if m.sessionStore == nil {
+		return nil // No session store, nothing to revoke
+	}
+	return m.sessionStore.Revoke(ctx, sessionID)
+}
+
+// RevokeAllSessions invalidates all sessions for a user (logout everywhere)
+func (m *JWTManager) RevokeAllSessions(ctx context.Context, userID string) error {
+	if m.sessionStore == nil {
+		return nil
+	}
+	return m.sessionStore.RevokeAllForUser(ctx, userID)
+}
+
+// ListSessions returns all active sessions for a user
+func (m *JWTManager) ListSessions(ctx context.Context, userID string) ([]*Session, error) {
+	if m.sessionStore == nil {
+		return nil, nil
+	}
+	return m.sessionStore.ListForUser(ctx, userID)
+}
+
+// ValidateToken validates an access token and returns claims
 func (m *JWTManager) ValidateToken(tokenString string) (*Claims, error) {
 	token, err := jwt.ParseWithClaims(tokenString, &Claims{}, func(token *jwt.Token) (interface{}, error) {
 		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
@@ -89,4 +205,67 @@ func (m *JWTManager) ValidateToken(tokenString string) (*Claims, error) {
 	}
 
 	return claims, nil
+}
+
+// ValidateRefreshToken validates a refresh token specifically
+func (m *JWTManager) ValidateRefreshToken(tokenString string) (*Claims, error) {
+	claims, err := m.ValidateToken(tokenString)
+	if err != nil {
+		return nil, err
+	}
+
+	if claims.TokenType != "refresh" {
+		return nil, fmt.Errorf("not a refresh token")
+	}
+
+	return claims, nil
+}
+
+// =============================================================================
+// Internal Token Generation
+// =============================================================================
+
+func (m *JWTManager) generateAccessToken(userID, phone string) (string, error) {
+	claims := &Claims{
+		UserID:    userID,
+		Phone:     phone,
+		TokenType: "access",
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(m.config.AccessTokenTTL)),
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+			Issuer:    "equishare",
+		},
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	return token.SignedString([]byte(m.config.Secret))
+}
+
+func (m *JWTManager) generateRefreshToken(userID, phone, sessionID string) (string, error) {
+	// Generate unique JWT ID for token uniqueness (prevents identical tokens when rotated)
+	jti, err := GenerateSessionID()
+	if err != nil {
+		return "", fmt.Errorf("failed to generate JWT ID: %w", err)
+	}
+
+	claims := &Claims{
+		UserID:    userID,
+		Phone:     phone,
+		SessionID: sessionID,
+		TokenType: "refresh",
+		RegisteredClaims: jwt.RegisteredClaims{
+			ID:        jti, // Unique token identifier
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(m.config.RefreshTokenTTL)),
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+			Issuer:    "equishare",
+		},
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	return token.SignedString([]byte(m.config.Secret))
+}
+
+// GetConfig returns the JWT configuration (for TTL info)
+func (m *JWTManager) GetConfig() *Config {
+	return m.config
 }

--- a/pkg/auth/jwt_test.go
+++ b/pkg/auth/jwt_test.go
@@ -1,6 +1,8 @@
 package auth
 
 import (
+	"context"
+	"sync"
 	"testing"
 	"time"
 )
@@ -28,6 +30,10 @@ func TestJWTManager_GenerateTokenPair(t *testing.T) {
 	if tokens.ExpiresIn != 900 {
 		t.Errorf("ExpiresIn = %d, want 900", tokens.ExpiresIn)
 	}
+
+	if tokens.SessionID == "" {
+		t.Error("SessionID should not be empty")
+	}
 }
 
 func TestJWTManager_ValidateToken(t *testing.T) {
@@ -50,6 +56,53 @@ func TestJWTManager_ValidateToken(t *testing.T) {
 
 	if claims.Phone != "+254712345678" {
 		t.Errorf("Phone = %s, want +254712345678", claims.Phone)
+	}
+
+	if claims.TokenType != "access" {
+		t.Errorf("TokenType = %s, want access", claims.TokenType)
+	}
+}
+
+func TestJWTManager_ValidateRefreshToken(t *testing.T) {
+	manager := NewJWTManager(&Config{
+		Secret:          "test-secret",
+		AccessTokenTTL:  15 * time.Minute,
+		RefreshTokenTTL: 24 * time.Hour,
+	})
+
+	tokens, _ := manager.GenerateTokenPair("user-123", "+254712345678")
+
+	claims, err := manager.ValidateRefreshToken(tokens.RefreshToken)
+	if err != nil {
+		t.Fatalf("ValidateRefreshToken() error = %v", err)
+	}
+
+	if claims.UserID != "user-123" {
+		t.Errorf("UserID = %s, want user-123", claims.UserID)
+	}
+
+	if claims.TokenType != "refresh" {
+		t.Errorf("TokenType = %s, want refresh", claims.TokenType)
+	}
+
+	if claims.SessionID == "" {
+		t.Error("SessionID should not be empty in refresh token")
+	}
+}
+
+func TestJWTManager_ValidateRefreshToken_NotRefresh(t *testing.T) {
+	manager := NewJWTManager(&Config{
+		Secret:          "test-secret",
+		AccessTokenTTL:  15 * time.Minute,
+		RefreshTokenTTL: 24 * time.Hour,
+	})
+
+	tokens, _ := manager.GenerateTokenPair("user-123", "+254712345678")
+
+	// Try to validate access token as refresh token
+	_, err := manager.ValidateRefreshToken(tokens.AccessToken)
+	if err == nil {
+		t.Error("ValidateRefreshToken() should return error for access token")
 	}
 }
 
@@ -76,4 +129,331 @@ func TestJWTManager_ValidateToken_WrongSecret(t *testing.T) {
 	if err == nil {
 		t.Error("ValidateToken() should return error for token signed with different secret")
 	}
+}
+
+func TestJWTManager_DefaultTTLs(t *testing.T) {
+	manager := NewJWTManager(&Config{Secret: "test-secret"})
+	cfg := manager.GetConfig()
+
+	if cfg.AccessTokenTTL != 15*time.Minute {
+		t.Errorf("Default AccessTokenTTL = %v, want 15m", cfg.AccessTokenTTL)
+	}
+
+	if cfg.RefreshTokenTTL != 7*24*time.Hour {
+		t.Errorf("Default RefreshTokenTTL = %v, want 7 days", cfg.RefreshTokenTTL)
+	}
+}
+
+// =============================================================================
+// Session-based Tests
+// =============================================================================
+
+func TestJWTManager_WithSessionStore(t *testing.T) {
+	store := NewMockSessionStore()
+	manager := NewJWTManager(&Config{
+		Secret:          "test-secret",
+		AccessTokenTTL:  15 * time.Minute,
+		RefreshTokenTTL: 24 * time.Hour,
+	}).WithSessionStore(store)
+
+	ctx := context.Background()
+	tokens, err := manager.GenerateTokenPairWithSession(ctx, "user-123", "+254712345678", "Test Agent", "127.0.0.1")
+	if err != nil {
+		t.Fatalf("GenerateTokenPairWithSession() error = %v", err)
+	}
+
+	// Verify session was created
+	session, err := store.Get(ctx, tokens.SessionID)
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if session == nil {
+		t.Fatal("Session should have been created")
+	}
+	if session.UserID != "user-123" {
+		t.Errorf("Session.UserID = %s, want user-123", session.UserID)
+	}
+	if session.UserAgent != "Test Agent" {
+		t.Errorf("Session.UserAgent = %s, want Test Agent", session.UserAgent)
+	}
+}
+
+func TestJWTManager_RefreshTokens_WithRotation(t *testing.T) {
+	store := NewMockSessionStore()
+	manager := NewJWTManager(&Config{
+		Secret:          "test-secret",
+		AccessTokenTTL:  15 * time.Minute,
+		RefreshTokenTTL: 24 * time.Hour,
+	}).WithSessionStore(store)
+
+	ctx := context.Background()
+	tokens1, _ := manager.GenerateTokenPairWithSession(ctx, "user-123", "+254712345678", "", "")
+
+	// Refresh tokens
+	tokens2, err := manager.RefreshTokens(ctx, tokens1.RefreshToken)
+	if err != nil {
+		t.Fatalf("RefreshTokens() error = %v", err)
+	}
+
+	if tokens2.RefreshToken == tokens1.RefreshToken {
+		t.Error("Refresh token should be rotated")
+	}
+
+	if tokens2.SessionID != tokens1.SessionID {
+		t.Error("Session ID should remain the same after rotation")
+	}
+
+	// Old refresh token should no longer work
+	_, err = manager.RefreshTokens(ctx, tokens1.RefreshToken)
+	if err == nil {
+		t.Error("Old refresh token should be invalid after rotation")
+	}
+
+	// New refresh token should work
+	tokens3, err := manager.RefreshTokens(ctx, tokens2.RefreshToken)
+	if err != nil {
+		t.Fatalf("RefreshTokens() with new token error = %v", err)
+	}
+	if tokens3.AccessToken == "" {
+		t.Error("Should get new access token")
+	}
+}
+
+func TestJWTManager_RevokeSession(t *testing.T) {
+	store := NewMockSessionStore()
+	manager := NewJWTManager(&Config{
+		Secret:          "test-secret",
+		AccessTokenTTL:  15 * time.Minute,
+		RefreshTokenTTL: 24 * time.Hour,
+	}).WithSessionStore(store)
+
+	ctx := context.Background()
+	tokens, _ := manager.GenerateTokenPairWithSession(ctx, "user-123", "+254712345678", "", "")
+
+	// Revoke session
+	err := manager.RevokeSession(ctx, tokens.SessionID)
+	if err != nil {
+		t.Fatalf("RevokeSession() error = %v", err)
+	}
+
+	// Refresh should fail after revocation
+	_, err = manager.RefreshTokens(ctx, tokens.RefreshToken)
+	if err == nil {
+		t.Error("RefreshTokens() should fail after session is revoked")
+	}
+}
+
+func TestJWTManager_RevokeAllSessions(t *testing.T) {
+	store := NewMockSessionStore()
+	manager := NewJWTManager(&Config{
+		Secret:          "test-secret",
+		AccessTokenTTL:  15 * time.Minute,
+		RefreshTokenTTL: 24 * time.Hour,
+	}).WithSessionStore(store)
+
+	ctx := context.Background()
+
+	// Create multiple sessions
+	tokens1, _ := manager.GenerateTokenPairWithSession(ctx, "user-123", "+254712345678", "", "")
+	tokens2, _ := manager.GenerateTokenPairWithSession(ctx, "user-123", "+254712345678", "", "")
+
+	// Verify both sessions exist
+	sessions, _ := manager.ListSessions(ctx, "user-123")
+	if len(sessions) != 2 {
+		t.Errorf("Expected 2 sessions, got %d", len(sessions))
+	}
+
+	// Revoke all sessions
+	err := manager.RevokeAllSessions(ctx, "user-123")
+	if err != nil {
+		t.Fatalf("RevokeAllSessions() error = %v", err)
+	}
+
+	// Both refreshes should fail
+	_, err = manager.RefreshTokens(ctx, tokens1.RefreshToken)
+	if err == nil {
+		t.Error("RefreshTokens() should fail for token 1")
+	}
+
+	_, err = manager.RefreshTokens(ctx, tokens2.RefreshToken)
+	if err == nil {
+		t.Error("RefreshTokens() should fail for token 2")
+	}
+}
+
+func TestJWTManager_ListSessions(t *testing.T) {
+	store := NewMockSessionStore()
+	manager := NewJWTManager(&Config{
+		Secret:          "test-secret",
+		AccessTokenTTL:  15 * time.Minute,
+		RefreshTokenTTL: 24 * time.Hour,
+	}).WithSessionStore(store)
+
+	ctx := context.Background()
+
+	// Create sessions for multiple users
+	manager.GenerateTokenPairWithSession(ctx, "user-1", "+254712345678", "Agent 1", "1.1.1.1")
+	manager.GenerateTokenPairWithSession(ctx, "user-1", "+254712345678", "Agent 2", "2.2.2.2")
+	manager.GenerateTokenPairWithSession(ctx, "user-2", "+254787654321", "Agent 3", "3.3.3.3")
+
+	sessions1, _ := manager.ListSessions(ctx, "user-1")
+	if len(sessions1) != 2 {
+		t.Errorf("User 1 should have 2 sessions, got %d", len(sessions1))
+	}
+
+	sessions2, _ := manager.ListSessions(ctx, "user-2")
+	if len(sessions2) != 1 {
+		t.Errorf("User 2 should have 1 session, got %d", len(sessions2))
+	}
+}
+
+// =============================================================================
+// Helper Functions Tests
+// =============================================================================
+
+func TestGenerateSessionID(t *testing.T) {
+	id1, err := GenerateSessionID()
+	if err != nil {
+		t.Fatalf("GenerateSessionID() error = %v", err)
+	}
+
+	if len(id1) != 64 { // 32 bytes = 64 hex characters
+		t.Errorf("SessionID length = %d, want 64", len(id1))
+	}
+
+	id2, _ := GenerateSessionID()
+	if id1 == id2 {
+		t.Error("Session IDs should be unique")
+	}
+}
+
+func TestHashToken(t *testing.T) {
+	token := "my-secret-token"
+	hash1 := HashToken(token)
+	hash2 := HashToken(token)
+
+	if hash1 != hash2 {
+		t.Error("Same token should produce same hash")
+	}
+
+	if len(hash1) != 64 { // SHA-256 = 64 hex characters
+		t.Errorf("Hash length = %d, want 64", len(hash1))
+	}
+
+	hash3 := HashToken("different-token")
+	if hash1 == hash3 {
+		t.Error("Different tokens should produce different hashes")
+	}
+}
+
+// =============================================================================
+// Mock Session Store
+// =============================================================================
+
+type MockSessionStore struct {
+	sessions     map[string]*Session
+	userSessions map[string][]string
+	mu           sync.RWMutex
+}
+
+func NewMockSessionStore() *MockSessionStore {
+	return &MockSessionStore{
+		sessions:     make(map[string]*Session),
+		userSessions: make(map[string][]string),
+	}
+}
+
+func (m *MockSessionStore) Create(ctx context.Context, session *Session) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.sessions[session.ID] = session
+	m.userSessions[session.UserID] = append(m.userSessions[session.UserID], session.ID)
+	return nil
+}
+
+func (m *MockSessionStore) Get(ctx context.Context, sessionID string) (*Session, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	session, exists := m.sessions[sessionID]
+	if !exists {
+		return nil, nil
+	}
+	return session, nil
+}
+
+func (m *MockSessionStore) Validate(ctx context.Context, sessionID, tokenHash string) (*Session, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	session, exists := m.sessions[sessionID]
+	if !exists {
+		return nil, nil
+	}
+	if session.TokenHash != tokenHash {
+		return nil, nil
+	}
+	if time.Now().After(session.ExpiresAt) {
+		return nil, nil
+	}
+	return session, nil
+}
+
+func (m *MockSessionStore) Rotate(ctx context.Context, sessionID, newTokenHash string, newExpiry time.Time) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	session, exists := m.sessions[sessionID]
+	if !exists {
+		return nil
+	}
+	session.TokenHash = newTokenHash
+	session.ExpiresAt = newExpiry
+	return nil
+}
+
+func (m *MockSessionStore) Revoke(ctx context.Context, sessionID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	session, exists := m.sessions[sessionID]
+	if exists {
+		// Remove from user sessions
+		userSessions := m.userSessions[session.UserID]
+		for i, id := range userSessions {
+			if id == sessionID {
+				m.userSessions[session.UserID] = append(userSessions[:i], userSessions[i+1:]...)
+				break
+			}
+		}
+	}
+	delete(m.sessions, sessionID)
+	return nil
+}
+
+func (m *MockSessionStore) RevokeAllForUser(ctx context.Context, userID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	sessionIDs := m.userSessions[userID]
+	for _, id := range sessionIDs {
+		delete(m.sessions, id)
+	}
+	delete(m.userSessions, userID)
+	return nil
+}
+
+func (m *MockSessionStore) ListForUser(ctx context.Context, userID string) ([]*Session, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	sessionIDs := m.userSessions[userID]
+	sessions := make([]*Session, 0, len(sessionIDs))
+	for _, id := range sessionIDs {
+		if session, exists := m.sessions[id]; exists {
+			sessions = append(sessions, session)
+		}
+	}
+	return sessions, nil
 }

--- a/pkg/auth/session.go
+++ b/pkg/auth/session.go
@@ -1,0 +1,253 @@
+package auth
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// =============================================================================
+// Session Management
+// =============================================================================
+// Sessions track active refresh tokens for users. When a refresh token is used,
+// it is rotated (old one invalidated, new one issued). On logout, the session
+// is revoked immediately.
+//
+// Redis Key Schema:
+//   - session:{session_id} -> user_id (TTL = refresh token TTL)
+//   - user_sessions:{user_id} -> set of session_ids (for logout all)
+// =============================================================================
+
+// Session represents an active user session
+type Session struct {
+	ID        string    `json:"id"`
+	UserID    string    `json:"user_id"`
+	TokenHash string    `json:"token_hash"` // Hash of refresh token
+	CreatedAt time.Time `json:"created_at"`
+	ExpiresAt time.Time `json:"expires_at"`
+	UserAgent string    `json:"user_agent,omitempty"`
+	IPAddress string    `json:"ip_address,omitempty"`
+}
+
+// SessionStore defines the interface for session storage
+type SessionStore interface {
+	// Create creates a new session and returns the session ID
+	Create(ctx context.Context, session *Session) error
+
+	// Get retrieves a session by ID
+	Get(ctx context.Context, sessionID string) (*Session, error)
+
+	// Validate checks if a session exists and the token hash matches
+	Validate(ctx context.Context, sessionID, tokenHash string) (*Session, error)
+
+	// Rotate updates the token hash for a session (token rotation)
+	Rotate(ctx context.Context, sessionID, newTokenHash string, newExpiry time.Time) error
+
+	// Revoke invalidates a specific session
+	Revoke(ctx context.Context, sessionID string) error
+
+	// RevokeAllForUser invalidates all sessions for a user
+	RevokeAllForUser(ctx context.Context, userID string) error
+
+	// ListForUser returns all active sessions for a user
+	ListForUser(ctx context.Context, userID string) ([]*Session, error)
+}
+
+// RedisSessionStore implements SessionStore using Redis
+type RedisSessionStore struct {
+	client *redis.Client
+	ttl    time.Duration
+}
+
+// NewRedisSessionStore creates a new Redis-based session store
+func NewRedisSessionStore(client *redis.Client, refreshTokenTTL time.Duration) *RedisSessionStore {
+	return &RedisSessionStore{
+		client: client,
+		ttl:    refreshTokenTTL,
+	}
+}
+
+func sessionKey(sessionID string) string {
+	return fmt.Sprintf("session:%s", sessionID)
+}
+
+func userSessionsKey(userID string) string {
+	return fmt.Sprintf("user_sessions:%s", userID)
+}
+
+func (s *RedisSessionStore) Create(ctx context.Context, session *Session) error {
+	pipe := s.client.Pipeline()
+
+	// Store session data
+	key := sessionKey(session.ID)
+	pipe.HSet(ctx, key,
+		"user_id", session.UserID,
+		"token_hash", session.TokenHash,
+		"created_at", session.CreatedAt.Unix(),
+		"expires_at", session.ExpiresAt.Unix(),
+		"user_agent", session.UserAgent,
+		"ip_address", session.IPAddress,
+	)
+	pipe.ExpireAt(ctx, key, session.ExpiresAt)
+
+	// Add to user's session set
+	pipe.SAdd(ctx, userSessionsKey(session.UserID), session.ID)
+	pipe.ExpireAt(ctx, userSessionsKey(session.UserID), session.ExpiresAt.Add(24*time.Hour))
+
+	_, err := pipe.Exec(ctx)
+	return err
+}
+
+func (s *RedisSessionStore) Get(ctx context.Context, sessionID string) (*Session, error) {
+	key := sessionKey(sessionID)
+	data, err := s.client.HGetAll(ctx, key).Result()
+	if err != nil {
+		return nil, err
+	}
+	if len(data) == 0 {
+		return nil, nil // Session not found
+	}
+
+	return parseSessionData(sessionID, data)
+}
+
+func (s *RedisSessionStore) Validate(ctx context.Context, sessionID, tokenHash string) (*Session, error) {
+	session, err := s.Get(ctx, sessionID)
+	if err != nil {
+		return nil, err
+	}
+	if session == nil {
+		return nil, nil // Session not found
+	}
+
+	// Check token hash matches
+	if session.TokenHash != tokenHash {
+		return nil, nil // Token doesn't match (possibly reused after rotation)
+	}
+
+	// Check expiry
+	if time.Now().After(session.ExpiresAt) {
+		// Clean up expired session
+		s.Revoke(ctx, sessionID)
+		return nil, nil
+	}
+
+	return session, nil
+}
+
+func (s *RedisSessionStore) Rotate(ctx context.Context, sessionID, newTokenHash string, newExpiry time.Time) error {
+	key := sessionKey(sessionID)
+
+	pipe := s.client.Pipeline()
+	pipe.HSet(ctx, key, "token_hash", newTokenHash, "expires_at", newExpiry.Unix())
+	pipe.ExpireAt(ctx, key, newExpiry)
+	_, err := pipe.Exec(ctx)
+
+	return err
+}
+
+func (s *RedisSessionStore) Revoke(ctx context.Context, sessionID string) error {
+	// Get session to find user ID
+	session, err := s.Get(ctx, sessionID)
+	if err != nil {
+		return err
+	}
+
+	pipe := s.client.Pipeline()
+
+	// Delete session
+	pipe.Del(ctx, sessionKey(sessionID))
+
+	// Remove from user's session set
+	if session != nil {
+		pipe.SRem(ctx, userSessionsKey(session.UserID), sessionID)
+	}
+
+	_, err = pipe.Exec(ctx)
+	return err
+}
+
+func (s *RedisSessionStore) RevokeAllForUser(ctx context.Context, userID string) error {
+	// Get all session IDs for user
+	sessionIDs, err := s.client.SMembers(ctx, userSessionsKey(userID)).Result()
+	if err != nil {
+		return err
+	}
+
+	if len(sessionIDs) == 0 {
+		return nil
+	}
+
+	pipe := s.client.Pipeline()
+
+	// Delete all sessions
+	for _, sessionID := range sessionIDs {
+		pipe.Del(ctx, sessionKey(sessionID))
+	}
+
+	// Delete the set
+	pipe.Del(ctx, userSessionsKey(userID))
+
+	_, err = pipe.Exec(ctx)
+	return err
+}
+
+func (s *RedisSessionStore) ListForUser(ctx context.Context, userID string) ([]*Session, error) {
+	sessionIDs, err := s.client.SMembers(ctx, userSessionsKey(userID)).Result()
+	if err != nil {
+		return nil, err
+	}
+
+	sessions := make([]*Session, 0, len(sessionIDs))
+	for _, sessionID := range sessionIDs {
+		session, err := s.Get(ctx, sessionID)
+		if err != nil {
+			continue
+		}
+		if session != nil {
+			sessions = append(sessions, session)
+		}
+	}
+
+	return sessions, nil
+}
+
+func parseSessionData(sessionID string, data map[string]string) (*Session, error) {
+	var createdAt, expiresAt int64
+	fmt.Sscanf(data["created_at"], "%d", &createdAt)
+	fmt.Sscanf(data["expires_at"], "%d", &expiresAt)
+
+	return &Session{
+		ID:        sessionID,
+		UserID:    data["user_id"],
+		TokenHash: data["token_hash"],
+		CreatedAt: time.Unix(createdAt, 0),
+		ExpiresAt: time.Unix(expiresAt, 0),
+		UserAgent: data["user_agent"],
+		IPAddress: data["ip_address"],
+	}, nil
+}
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
+
+// GenerateSessionID creates a cryptographically secure session ID
+func GenerateSessionID() (string, error) {
+	bytes := make([]byte, 32)
+	if _, err := rand.Read(bytes); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(bytes), nil
+}
+
+// HashToken creates a SHA-256 hash of a token for storage
+func HashToken(token string) string {
+	hash := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(hash[:])
+}


### PR DESCRIPTION
## Summary
- Add session-based token management with Redis storage
- Implement refresh token rotation (new token on each refresh, old token invalidated)
- Add session revocation for logout (single session and logout everywhere)
- Add unique JWT IDs (JTI) to ensure token uniqueness during rotation

## Key Features
- **Session tracking**: Refresh tokens are bound to sessions stored in Redis
- **Token rotation**: Each refresh generates a new refresh token, invalidating the old one
- **Logout single session**: `RevokeSession(sessionID)` invalidates a specific session
- **Logout everywhere**: `RevokeAllSessions(userID)` invalidates all user sessions
- **Session listing**: `ListSessions(userID)` returns all active sessions for a user

## Files Changed
- `pkg/auth/session.go` - Session struct, SessionStore interface, RedisSessionStore
- `pkg/auth/jwt.go` - Enhanced JWTManager with session support
- `pkg/auth/jwt_test.go` - Comprehensive tests with MockSessionStore

## Test plan
- [x] All existing JWT tests pass
- [x] New session-based tests pass
- [x] Token rotation produces unique tokens
- [x] Old refresh tokens are invalidated after rotation
- [x] Session revocation prevents token refresh

Closes #26