### PR TITLE
feat(k8s): setup Kubernetes manifests for production deployment

### DIFF
--- a/docs/kubernetes-deployment.md
+++ b/docs/kubernetes-deployment.md
@@ -1,0 +1,299 @@
+# Kubernetes Deployment Guide
+
+This guide covers deploying EquiShare to Kubernetes using Kustomize overlays.
+
+## Directory Structure
+
+```
+infrastructure/k8s/
+├── base/                    # Common resources
+│   ├── kustomization.yaml
+│   ├── namespace.yaml
+│   ├── service-account.yaml
+│   ├── network-policy.yaml
+│   └── <service>/
+│       ├── deployment.yaml
+│       ├── service.yaml
+│       └── hpa.yaml
+├── staging/                 # Staging overlay
+│   └── kustomization.yaml
+└── production/              # Production overlay
+    ├── kustomization.yaml
+    ├── pdb.yaml
+    ├── ingress.yaml
+    └── service-account.yaml
+```
+
+## Prerequisites
+
+1. **Kubernetes cluster** (GKE, EKS, AKS, or similar)
+2. **kubectl** configured to access the cluster
+3. **Kustomize** (built into kubectl v1.14+)
+4. **Secrets** configured (see Secrets section)
+
+## Quick Start
+
+### Deploy to Staging
+
+```bash
+# Preview what will be deployed
+kubectl kustomize infrastructure/k8s/staging/
+
+# Apply to cluster
+kubectl apply -k infrastructure/k8s/staging/
+```
+
+### Deploy to Production
+
+```bash
+# Preview
+kubectl kustomize infrastructure/k8s/production/
+
+# Apply
+kubectl apply -k infrastructure/k8s/production/
+```
+
+## Services Overview
+
+| Service | Port | Replicas (Prod) | Purpose |
+|---------|------|-----------------|---------|
+| api-gateway | 8000 | 2-5 | Entry point, routing |
+| auth-service | 8001 | 2-3 | Authentication |
+| user-service | 8002 | 2-3 | User profiles |
+| trading-service | 8003 | 2-5 | Order execution |
+| payment-service | 8004 | 2-3 | M-Pesa payments |
+| ussd-service | 8005 | 2-3 | USSD interface |
+| notification-service | 8006 | 2-4 | SMS/Push/Email |
+| market-data-service | 8007 | 2-4 | Real-time prices |
+| portfolio-service | 8008 | 2-3 | Portfolio tracking |
+
+## Secrets Configuration
+
+Before deploying, create the required secrets:
+
+```bash
+# Database credentials
+kubectl create secret generic equishare-db-credentials \
+  --namespace=equishare-production \
+  --from-literal=username=equishare \
+  --from-literal=password='YOUR_DB_PASSWORD'
+
+# JWT secret
+kubectl create secret generic equishare-jwt-secret \
+  --namespace=equishare-production \
+  --from-literal=secret='YOUR_JWT_SECRET_MIN_32_CHARS'
+
+# M-Pesa credentials
+kubectl create secret generic equishare-mpesa-credentials \
+  --namespace=equishare-production \
+  --from-literal=consumer_key='YOUR_CONSUMER_KEY' \
+  --from-literal=consumer_secret='YOUR_CONSUMER_SECRET' \
+  --from-literal=pass_key='YOUR_PASS_KEY'
+
+# Alpaca credentials
+kubectl create secret generic equishare-alpaca-credentials \
+  --namespace=equishare-production \
+  --from-literal=api_key='YOUR_API_KEY' \
+  --from-literal=api_secret='YOUR_API_SECRET'
+```
+
+### Using External Secrets Operator (Recommended)
+
+For production, use External Secrets Operator with AWS SSM or GCP Secret Manager:
+
+```yaml
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: equishare-db-credentials
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: gcp-secrets
+  target:
+    name: equishare-db-credentials
+  data:
+    - secretKey: username
+      remoteRef:
+        key: equishare-db-username
+    - secretKey: password
+      remoteRef:
+        key: equishare-db-password
+```
+
+## Resource Configuration
+
+### Staging
+
+Staging uses minimal resources for cost efficiency:
+- 1 replica per service
+- 50m CPU request, 200m limit
+- 64Mi memory request, 256Mi limit
+- HPA disabled (max 2 replicas)
+
+### Production
+
+Production is configured for high availability:
+- 2+ replicas per service
+- Full resource allocation
+- HPA enabled with auto-scaling
+- PodDisruptionBudgets for zero-downtime updates
+- Topology spread across zones
+
+## Health Checks
+
+All services implement three probe types:
+
+1. **Liveness Probe** - Restarts unhealthy pods
+   ```yaml
+   livenessProbe:
+     httpGet:
+       path: /health
+       port: http
+     initialDelaySeconds: 15
+     periodSeconds: 20
+   ```
+
+2. **Readiness Probe** - Controls traffic routing
+   ```yaml
+   readinessProbe:
+     httpGet:
+       path: /health
+       port: http
+     initialDelaySeconds: 5
+     periodSeconds: 10
+   ```
+
+3. **Startup Probe** - Handles slow-starting containers
+   ```yaml
+   startupProbe:
+     httpGet:
+       path: /health
+       port: http
+     initialDelaySeconds: 10
+     failureThreshold: 30
+   ```
+
+## Ingress Configuration
+
+Production uses NGINX Ingress with TLS:
+
+| Domain | Service | Notes |
+|--------|---------|-------|
+| api.equishare.com | api-gateway | Main API |
+| ussd.equishare.com | ussd-service | Africa's Talking callbacks |
+| mpesa.equishare.com | payment-service | M-Pesa callbacks |
+
+### TLS Certificates
+
+Using cert-manager with Let's Encrypt:
+
+```bash
+# Install cert-manager
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.13.0/cert-manager.yaml
+
+# Create ClusterIssuer
+cat <<EOF | kubectl apply -f -
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: admin@equishare.com
+    privateKeySecretRef:
+      name: letsencrypt-prod
+    solvers:
+      - http01:
+          ingress:
+            class: nginx
+EOF
+```
+
+## Scaling
+
+### Manual Scaling
+
+```bash
+kubectl scale deployment/prod-trading-service \
+  --replicas=5 \
+  -n equishare-production
+```
+
+### HPA Scaling
+
+HPA automatically scales based on CPU/memory:
+
+```bash
+# View HPA status
+kubectl get hpa -n equishare-production
+
+# Describe specific HPA
+kubectl describe hpa prod-api-gateway -n equishare-production
+```
+
+## Monitoring Deployment
+
+```bash
+# Watch rollout status
+kubectl rollout status deployment/prod-api-gateway -n equishare-production
+
+# View pods
+kubectl get pods -n equishare-production -l app.kubernetes.io/name=api-gateway
+
+# View logs
+kubectl logs -f deployment/prod-api-gateway -n equishare-production
+
+# View events
+kubectl get events -n equishare-production --sort-by='.lastTimestamp'
+```
+
+## Rollback
+
+```bash
+# View rollout history
+kubectl rollout history deployment/prod-api-gateway -n equishare-production
+
+# Rollback to previous version
+kubectl rollout undo deployment/prod-api-gateway -n equishare-production
+
+# Rollback to specific revision
+kubectl rollout undo deployment/prod-api-gateway --to-revision=2 -n equishare-production
+```
+
+## Network Policies
+
+Network policies restrict pod-to-pod communication:
+
+- Default deny all ingress
+- Allow same-namespace communication
+- Allow api-gateway external access
+- Allow egress to PostgreSQL, Redis, Kafka
+- Allow DNS resolution
+
+## Troubleshooting
+
+### Pod not starting
+
+```bash
+kubectl describe pod <pod-name> -n equishare-production
+kubectl logs <pod-name> -n equishare-production --previous
+```
+
+### Service not accessible
+
+```bash
+kubectl get endpoints <service-name> -n equishare-production
+kubectl run debug --rm -it --image=busybox -- /bin/sh
+# From debug pod: wget -qO- http://service-name:port/health
+```
+
+### HPA not scaling
+
+```bash
+kubectl describe hpa <hpa-name> -n equishare-production
+# Check if metrics-server is running
+kubectl get pods -n kube-system | grep metrics-server
+```

--- a/infrastructure/k8s/base/api-gateway/deployment.yaml
+++ b/infrastructure/k8s/base/api-gateway/deployment.yaml
@@ -1,0 +1,152 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api-gateway
+  labels:
+    app.kubernetes.io/name: api-gateway
+    app.kubernetes.io/component: gateway
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: api-gateway
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: api-gateway
+        app.kubernetes.io/component: gateway
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8000"
+        prometheus.io/path: "/metrics"
+    spec:
+      serviceAccountName: equishare-service
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
+      containers:
+        - name: api-gateway
+          image: ghcr.io/rohianon/equishare-api-gateway:latest
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 8000
+              protocol: TCP
+          env:
+            - name: EQUISHARE_SERVER_HOST
+              value: "0.0.0.0"
+            - name: EQUISHARE_SERVER_PORT
+              value: "8000"
+            - name: EQUISHARE_ENV
+              valueFrom:
+                configMapKeyRef:
+                  name: equishare-config
+                  key: environment
+            - name: EQUISHARE_DATABASE_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: equishare-config
+                  key: database.host
+            - name: EQUISHARE_DATABASE_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: equishare-config
+                  key: database.port
+            - name: EQUISHARE_DATABASE_USER
+              valueFrom:
+                secretKeyRef:
+                  name: equishare-db-credentials
+                  key: username
+            - name: EQUISHARE_DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: equishare-db-credentials
+                  key: password
+            - name: EQUISHARE_DATABASE_DATABASE
+              valueFrom:
+                configMapKeyRef:
+                  name: equishare-config
+                  key: database.name
+            - name: EQUISHARE_REDIS_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: equishare-config
+                  key: redis.host
+            - name: EQUISHARE_REDIS_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: equishare-config
+                  key: redis.port
+            - name: EQUISHARE_KAFKA_BROKERS
+              valueFrom:
+                configMapKeyRef:
+                  name: equishare-config
+                  key: kafka.brokers
+            - name: EQUISHARE_JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: equishare-jwt-secret
+                  key: secret
+            - name: EQUISHARE_TELEMETRY_ENABLED
+              value: "true"
+            - name: EQUISHARE_TELEMETRY_SERVICE_NAME
+              value: "api-gateway"
+            - name: EQUISHARE_TELEMETRY_COLLECTOR_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: equishare-config
+                  key: telemetry.collector_url
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 30
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: api-gateway
+                topologyKey: kubernetes.io/hostname
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: api-gateway

--- a/infrastructure/k8s/base/api-gateway/hpa.yaml
+++ b/infrastructure/k8s/base/api-gateway/hpa.yaml
@@ -1,0 +1,43 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: api-gateway
+  labels:
+    app.kubernetes.io/name: api-gateway
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: api-gateway
+  minReplicas: 2
+  maxReplicas: 5
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 80
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+        - type: Percent
+          value: 10
+          periodSeconds: 60
+    scaleUp:
+      stabilizationWindowSeconds: 0
+      policies:
+        - type: Percent
+          value: 100
+          periodSeconds: 15
+        - type: Pods
+          value: 2
+          periodSeconds: 15
+      selectPolicy: Max

--- a/infrastructure/k8s/base/api-gateway/service.yaml
+++ b/infrastructure/k8s/base/api-gateway/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: api-gateway
+  labels:
+    app.kubernetes.io/name: api-gateway
+    app.kubernetes.io/component: gateway
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8000
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: api-gateway

--- a/infrastructure/k8s/base/auth-service/deployment.yaml
+++ b/infrastructure/k8s/base/auth-service/deployment.yaml
@@ -1,0 +1,87 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: auth-service
+  labels:
+    app.kubernetes.io/name: auth-service
+    app.kubernetes.io/component: backend
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: auth-service
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: auth-service
+        app.kubernetes.io/component: backend
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8001"
+        prometheus.io/path: "/metrics"
+    spec:
+      serviceAccountName: equishare-service
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
+      containers:
+        - name: auth-service
+          image: ghcr.io/rohianon/equishare-auth-service:latest
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 8001
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: equishare-common-env
+          env:
+            - name: EQUISHARE_SERVER_PORT
+              value: "8001"
+            - name: EQUISHARE_TELEMETRY_SERVICE_NAME
+              value: "auth-service"
+            - name: EQUISHARE_DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: equishare-db-credentials
+                  key: password
+            - name: EQUISHARE_JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: equishare-jwt-secret
+                  key: secret
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 300m
+              memory: 256Mi
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: auth-service
+                topologyKey: kubernetes.io/hostname

--- a/infrastructure/k8s/base/auth-service/hpa.yaml
+++ b/infrastructure/k8s/base/auth-service/hpa.yaml
@@ -1,0 +1,18 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: auth-service
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: auth-service
+  minReplicas: 2
+  maxReplicas: 3
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70

--- a/infrastructure/k8s/base/auth-service/service.yaml
+++ b/infrastructure/k8s/base/auth-service/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: auth-service
+  labels:
+    app.kubernetes.io/name: auth-service
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8001
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: auth-service

--- a/infrastructure/k8s/base/kustomization.yaml
+++ b/infrastructure/k8s/base/kustomization.yaml
@@ -1,0 +1,40 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: equishare
+
+resources:
+  - namespace.yaml
+  - service-account.yaml
+  - network-policy.yaml
+  - api-gateway/deployment.yaml
+  - api-gateway/service.yaml
+  - api-gateway/hpa.yaml
+  - auth-service/deployment.yaml
+  - auth-service/service.yaml
+  - auth-service/hpa.yaml
+  - user-service/deployment.yaml
+  - user-service/service.yaml
+  - user-service/hpa.yaml
+  - trading-service/deployment.yaml
+  - trading-service/service.yaml
+  - trading-service/hpa.yaml
+  - payment-service/deployment.yaml
+  - payment-service/service.yaml
+  - payment-service/hpa.yaml
+  - ussd-service/deployment.yaml
+  - ussd-service/service.yaml
+  - ussd-service/hpa.yaml
+  - notification-service/deployment.yaml
+  - notification-service/service.yaml
+  - notification-service/hpa.yaml
+  - market-data-service/deployment.yaml
+  - market-data-service/service.yaml
+  - market-data-service/hpa.yaml
+  - portfolio-service/deployment.yaml
+  - portfolio-service/service.yaml
+  - portfolio-service/hpa.yaml
+
+commonLabels:
+  app.kubernetes.io/part-of: equishare
+  app.kubernetes.io/managed-by: kustomize

--- a/infrastructure/k8s/base/market-data-service/deployment.yaml
+++ b/infrastructure/k8s/base/market-data-service/deployment.yaml
@@ -1,0 +1,87 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: market-data-service
+  labels:
+    app.kubernetes.io/name: market-data-service
+    app.kubernetes.io/component: backend
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: market-data-service
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: market-data-service
+        app.kubernetes.io/component: backend
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8007"
+        prometheus.io/path: "/metrics"
+    spec:
+      serviceAccountName: equishare-service
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
+      containers:
+        - name: market-data-service
+          image: ghcr.io/rohianon/equishare-market-data-service:latest
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 8007
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: equishare-common-env
+          env:
+            - name: EQUISHARE_SERVER_PORT
+              value: "8007"
+            - name: EQUISHARE_TELEMETRY_SERVICE_NAME
+              value: "market-data-service"
+            - name: EQUISHARE_DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: equishare-db-credentials
+                  key: password
+            - name: EQUISHARE_JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: equishare-jwt-secret
+                  key: secret
+          resources:
+            requests:
+              cpu: 200m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: market-data-service
+                topologyKey: kubernetes.io/hostname

--- a/infrastructure/k8s/base/market-data-service/hpa.yaml
+++ b/infrastructure/k8s/base/market-data-service/hpa.yaml
@@ -1,0 +1,18 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: market-data-service
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: market-data-service
+  minReplicas: 2
+  maxReplicas: 4
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70

--- a/infrastructure/k8s/base/market-data-service/service.yaml
+++ b/infrastructure/k8s/base/market-data-service/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: market-data-service
+  labels:
+    app.kubernetes.io/name: market-data-service
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8007
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: market-data-service

--- a/infrastructure/k8s/base/namespace.yaml
+++ b/infrastructure/k8s/base/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: equishare
+  labels:
+    app.kubernetes.io/name: equishare
+    app.kubernetes.io/managed-by: kustomize

--- a/infrastructure/k8s/base/network-policy.yaml
+++ b/infrastructure/k8s/base/network-policy.yaml
@@ -1,0 +1,132 @@
+---
+# Default deny all ingress traffic
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+
+---
+# Allow ingress from within the namespace
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-same-namespace
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector: {}
+
+---
+# Allow api-gateway to receive external traffic
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-api-gateway-ingress
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: api-gateway
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              name: ingress-nginx
+      ports:
+        - protocol: TCP
+          port: 8000
+
+---
+# Allow all services to access PostgreSQL
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-postgres-egress
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/part-of: equishare
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              app: postgresql
+      ports:
+        - protocol: TCP
+          port: 5432
+
+---
+# Allow all services to access Redis
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-redis-egress
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/part-of: equishare
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              app: redis
+      ports:
+        - protocol: TCP
+          port: 6379
+
+---
+# Allow all services to access Kafka
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-kafka-egress
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/part-of: equishare
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              app: kafka
+      ports:
+        - protocol: TCP
+          port: 9092
+
+---
+# Allow DNS resolution
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-dns-egress
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53

--- a/infrastructure/k8s/base/notification-service/deployment.yaml
+++ b/infrastructure/k8s/base/notification-service/deployment.yaml
@@ -1,0 +1,87 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: notification-service
+  labels:
+    app.kubernetes.io/name: notification-service
+    app.kubernetes.io/component: backend
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: notification-service
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: notification-service
+        app.kubernetes.io/component: backend
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8006"
+        prometheus.io/path: "/metrics"
+    spec:
+      serviceAccountName: equishare-service
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
+      containers:
+        - name: notification-service
+          image: ghcr.io/rohianon/equishare-notification-service:latest
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 8006
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: equishare-common-env
+          env:
+            - name: EQUISHARE_SERVER_PORT
+              value: "8006"
+            - name: EQUISHARE_TELEMETRY_SERVICE_NAME
+              value: "notification-service"
+            - name: EQUISHARE_DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: equishare-db-credentials
+                  key: password
+            - name: EQUISHARE_JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: equishare-jwt-secret
+                  key: secret
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 300m
+              memory: 256Mi
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: notification-service
+                topologyKey: kubernetes.io/hostname

--- a/infrastructure/k8s/base/notification-service/hpa.yaml
+++ b/infrastructure/k8s/base/notification-service/hpa.yaml
@@ -1,0 +1,18 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: notification-service
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: notification-service
+  minReplicas: 2
+  maxReplicas: 4
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70

--- a/infrastructure/k8s/base/notification-service/service.yaml
+++ b/infrastructure/k8s/base/notification-service/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: notification-service
+  labels:
+    app.kubernetes.io/name: notification-service
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8006
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: notification-service

--- a/infrastructure/k8s/base/payment-service/deployment.yaml
+++ b/infrastructure/k8s/base/payment-service/deployment.yaml
@@ -1,0 +1,87 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: payment-service
+  labels:
+    app.kubernetes.io/name: payment-service
+    app.kubernetes.io/component: backend
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: payment-service
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: payment-service
+        app.kubernetes.io/component: backend
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8004"
+        prometheus.io/path: "/metrics"
+    spec:
+      serviceAccountName: equishare-service
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
+      containers:
+        - name: payment-service
+          image: ghcr.io/rohianon/equishare-payment-service:latest
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 8004
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: equishare-common-env
+          env:
+            - name: EQUISHARE_SERVER_PORT
+              value: "8004"
+            - name: EQUISHARE_TELEMETRY_SERVICE_NAME
+              value: "payment-service"
+            - name: EQUISHARE_DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: equishare-db-credentials
+                  key: password
+            - name: EQUISHARE_JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: equishare-jwt-secret
+                  key: secret
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: payment-service
+                topologyKey: kubernetes.io/hostname

--- a/infrastructure/k8s/base/payment-service/hpa.yaml
+++ b/infrastructure/k8s/base/payment-service/hpa.yaml
@@ -1,0 +1,18 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: payment-service
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: payment-service
+  minReplicas: 2
+  maxReplicas: 3
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70

--- a/infrastructure/k8s/base/payment-service/service.yaml
+++ b/infrastructure/k8s/base/payment-service/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: payment-service
+  labels:
+    app.kubernetes.io/name: payment-service
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8004
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: payment-service

--- a/infrastructure/k8s/base/portfolio-service/deployment.yaml
+++ b/infrastructure/k8s/base/portfolio-service/deployment.yaml
@@ -1,0 +1,87 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: portfolio-service
+  labels:
+    app.kubernetes.io/name: portfolio-service
+    app.kubernetes.io/component: backend
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: portfolio-service
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: portfolio-service
+        app.kubernetes.io/component: backend
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8008"
+        prometheus.io/path: "/metrics"
+    spec:
+      serviceAccountName: equishare-service
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
+      containers:
+        - name: portfolio-service
+          image: ghcr.io/rohianon/equishare-portfolio-service:latest
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 8008
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: equishare-common-env
+          env:
+            - name: EQUISHARE_SERVER_PORT
+              value: "8008"
+            - name: EQUISHARE_TELEMETRY_SERVICE_NAME
+              value: "portfolio-service"
+            - name: EQUISHARE_DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: equishare-db-credentials
+                  key: password
+            - name: EQUISHARE_JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: equishare-jwt-secret
+                  key: secret
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 300m
+              memory: 256Mi
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: portfolio-service
+                topologyKey: kubernetes.io/hostname

--- a/infrastructure/k8s/base/portfolio-service/hpa.yaml
+++ b/infrastructure/k8s/base/portfolio-service/hpa.yaml
@@ -1,0 +1,18 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: portfolio-service
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: portfolio-service
+  minReplicas: 2
+  maxReplicas: 3
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70

--- a/infrastructure/k8s/base/portfolio-service/service.yaml
+++ b/infrastructure/k8s/base/portfolio-service/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: portfolio-service
+  labels:
+    app.kubernetes.io/name: portfolio-service
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8008
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: portfolio-service

--- a/infrastructure/k8s/base/service-account.yaml
+++ b/infrastructure/k8s/base/service-account.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: equishare-service
+  labels:
+    app.kubernetes.io/name: equishare-service
+    app.kubernetes.io/part-of: equishare

--- a/infrastructure/k8s/base/trading-service/deployment.yaml
+++ b/infrastructure/k8s/base/trading-service/deployment.yaml
@@ -1,0 +1,87 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: trading-service
+  labels:
+    app.kubernetes.io/name: trading-service
+    app.kubernetes.io/component: backend
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: trading-service
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: trading-service
+        app.kubernetes.io/component: backend
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8003"
+        prometheus.io/path: "/metrics"
+    spec:
+      serviceAccountName: equishare-service
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
+      containers:
+        - name: trading-service
+          image: ghcr.io/rohianon/equishare-trading-service:latest
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 8003
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: equishare-common-env
+          env:
+            - name: EQUISHARE_SERVER_PORT
+              value: "8003"
+            - name: EQUISHARE_TELEMETRY_SERVICE_NAME
+              value: "trading-service"
+            - name: EQUISHARE_DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: equishare-db-credentials
+                  key: password
+            - name: EQUISHARE_JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: equishare-jwt-secret
+                  key: secret
+          resources:
+            requests:
+              cpu: 200m
+              memory: 256Mi
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: trading-service
+                topologyKey: kubernetes.io/hostname

--- a/infrastructure/k8s/base/trading-service/hpa.yaml
+++ b/infrastructure/k8s/base/trading-service/hpa.yaml
@@ -1,0 +1,18 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: trading-service
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: trading-service
+  minReplicas: 2
+  maxReplicas: 5
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70

--- a/infrastructure/k8s/base/trading-service/service.yaml
+++ b/infrastructure/k8s/base/trading-service/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: trading-service
+  labels:
+    app.kubernetes.io/name: trading-service
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8003
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: trading-service

--- a/infrastructure/k8s/base/user-service/deployment.yaml
+++ b/infrastructure/k8s/base/user-service/deployment.yaml
@@ -1,0 +1,87 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: user-service
+  labels:
+    app.kubernetes.io/name: user-service
+    app.kubernetes.io/component: backend
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: user-service
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: user-service
+        app.kubernetes.io/component: backend
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8002"
+        prometheus.io/path: "/metrics"
+    spec:
+      serviceAccountName: equishare-service
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
+      containers:
+        - name: user-service
+          image: ghcr.io/rohianon/equishare-user-service:latest
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 8002
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: equishare-common-env
+          env:
+            - name: EQUISHARE_SERVER_PORT
+              value: "8002"
+            - name: EQUISHARE_TELEMETRY_SERVICE_NAME
+              value: "user-service"
+            - name: EQUISHARE_DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: equishare-db-credentials
+                  key: password
+            - name: EQUISHARE_JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: equishare-jwt-secret
+                  key: secret
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 300m
+              memory: 256Mi
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: user-service
+                topologyKey: kubernetes.io/hostname

--- a/infrastructure/k8s/base/user-service/hpa.yaml
+++ b/infrastructure/k8s/base/user-service/hpa.yaml
@@ -1,0 +1,18 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: user-service
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: user-service
+  minReplicas: 2
+  maxReplicas: 3
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70

--- a/infrastructure/k8s/base/user-service/service.yaml
+++ b/infrastructure/k8s/base/user-service/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: user-service
+  labels:
+    app.kubernetes.io/name: user-service
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8002
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: user-service

--- a/infrastructure/k8s/base/ussd-service/deployment.yaml
+++ b/infrastructure/k8s/base/ussd-service/deployment.yaml
@@ -1,0 +1,87 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ussd-service
+  labels:
+    app.kubernetes.io/name: ussd-service
+    app.kubernetes.io/component: backend
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ussd-service
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ussd-service
+        app.kubernetes.io/component: backend
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8005"
+        prometheus.io/path: "/metrics"
+    spec:
+      serviceAccountName: equishare-service
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
+      containers:
+        - name: ussd-service
+          image: ghcr.io/rohianon/equishare-ussd-service:latest
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 8005
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: equishare-common-env
+          env:
+            - name: EQUISHARE_SERVER_PORT
+              value: "8005"
+            - name: EQUISHARE_TELEMETRY_SERVICE_NAME
+              value: "ussd-service"
+            - name: EQUISHARE_DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: equishare-db-credentials
+                  key: password
+            - name: EQUISHARE_JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: equishare-jwt-secret
+                  key: secret
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 300m
+              memory: 256Mi
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: ussd-service
+                topologyKey: kubernetes.io/hostname

--- a/infrastructure/k8s/base/ussd-service/hpa.yaml
+++ b/infrastructure/k8s/base/ussd-service/hpa.yaml
@@ -1,0 +1,18 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: ussd-service
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: ussd-service
+  minReplicas: 2
+  maxReplicas: 3
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70

--- a/infrastructure/k8s/base/ussd-service/service.yaml
+++ b/infrastructure/k8s/base/ussd-service/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ussd-service
+  labels:
+    app.kubernetes.io/name: ussd-service
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8005
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: ussd-service

--- a/infrastructure/k8s/production/ingress.yaml
+++ b/infrastructure/k8s/production/ingress.yaml
@@ -1,0 +1,96 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: equishare-ingress
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/proxy-body-size: "10m"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "60"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "60"
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: "60"
+    nginx.ingress.kubernetes.io/rate-limit: "100"
+    nginx.ingress.kubernetes.io/rate-limit-window: "1m"
+    nginx.ingress.kubernetes.io/rate-limit-connections: "10"
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/cors-allow-origin: "https://app.equishare.com"
+    nginx.ingress.kubernetes.io/cors-allow-methods: "GET, PUT, POST, DELETE, PATCH, OPTIONS"
+    nginx.ingress.kubernetes.io/cors-allow-headers: "DNT,X-CustomHeader,X-LANG,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,X-Api-Key,X-Device-Id,Authorization"
+    nginx.ingress.kubernetes.io/enable-cors: "true"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - api.equishare.com
+      secretName: equishare-tls
+  rules:
+    - host: api.equishare.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: prod-api-gateway
+                port:
+                  number: 8000
+
+---
+# Separate ingress for USSD callbacks (no rate limiting)
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: equishare-ussd-ingress
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/proxy-body-size: "1m"
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - ussd.equishare.com
+      secretName: equishare-ussd-tls
+  rules:
+    - host: ussd.equishare.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: prod-ussd-service
+                port:
+                  number: 8005
+
+---
+# Separate ingress for M-Pesa callbacks (no rate limiting, specific IP whitelisting)
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: equishare-mpesa-ingress
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/proxy-body-size: "1m"
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    # Safaricom IP ranges should be whitelisted here
+    # nginx.ingress.kubernetes.io/whitelist-source-range: "196.201.214.0/24,196.201.216.0/24"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - mpesa.equishare.com
+      secretName: equishare-mpesa-tls
+  rules:
+    - host: mpesa.equishare.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: prod-payment-service
+                port:
+                  number: 8004

--- a/infrastructure/k8s/production/kustomization.yaml
+++ b/infrastructure/k8s/production/kustomization.yaml
@@ -1,0 +1,105 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: equishare-production
+
+resources:
+  - ../base
+  - pdb.yaml
+  - ingress.yaml
+
+namePrefix: prod-
+
+commonLabels:
+  environment: production
+
+commonAnnotations:
+  app.kubernetes.io/environment: production
+
+configMapGenerator:
+  - name: equishare-config
+    literals:
+      - environment=production
+      - database.host=postgres-production.database.svc.cluster.local
+      - database.port=5432
+      - database.name=equishare_production
+      - redis.host=redis-production.cache.svc.cluster.local
+      - redis.port=6379
+      - kafka.brokers=kafka-production.messaging.svc.cluster.local:9092
+      - telemetry.collector_url=http://jaeger.observability.svc.cluster.local:4317
+
+  - name: equishare-common-env
+    literals:
+      - EQUISHARE_SERVER_HOST=0.0.0.0
+      - EQUISHARE_ENV=production
+      - EQUISHARE_DATABASE_HOST=postgres-production.database.svc.cluster.local
+      - EQUISHARE_DATABASE_PORT=5432
+      - EQUISHARE_DATABASE_DATABASE=equishare_production
+      - EQUISHARE_DATABASE_USER=equishare
+      - EQUISHARE_DATABASE_SSL_MODE=require
+      - EQUISHARE_REDIS_HOST=redis-production.cache.svc.cluster.local
+      - EQUISHARE_REDIS_PORT=6379
+      - EQUISHARE_KAFKA_BROKERS=kafka-production.messaging.svc.cluster.local:9092
+      - EQUISHARE_TELEMETRY_ENABLED=true
+      - EQUISHARE_TELEMETRY_SAMPLE_RATE=0.1
+      - EQUISHARE_TELEMETRY_COLLECTOR_URL=http://jaeger.observability.svc.cluster.local:4317
+
+patches:
+  # Add GKE Workload Identity annotation to service account
+  - target:
+      kind: ServiceAccount
+      name: equishare-service
+    patch: |-
+      - op: add
+        path: /metadata/annotations
+        value:
+          iam.gke.io/gcp-service-account: equishare-service@PROJECT_ID.iam.gserviceaccount.com
+
+  # Enable topology spread for production
+  - target:
+      kind: Deployment
+    patch: |-
+      - op: add
+        path: /spec/template/spec/topologySpreadConstraints
+        value:
+          - maxSkew: 1
+            topologyKey: topology.kubernetes.io/zone
+            whenUnsatisfiable: DoNotSchedule
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/part-of: equishare
+
+  # Add startup probe timeout
+  - target:
+      kind: Deployment
+    patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/startupProbe
+        value:
+          httpGet:
+            path: /health
+            port: http
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          timeoutSeconds: 5
+          failureThreshold: 30
+
+images:
+  - name: ghcr.io/rohianon/equishare-api-gateway
+    newTag: v1.0.0
+  - name: ghcr.io/rohianon/equishare-auth-service
+    newTag: v1.0.0
+  - name: ghcr.io/rohianon/equishare-user-service
+    newTag: v1.0.0
+  - name: ghcr.io/rohianon/equishare-trading-service
+    newTag: v1.0.0
+  - name: ghcr.io/rohianon/equishare-payment-service
+    newTag: v1.0.0
+  - name: ghcr.io/rohianon/equishare-ussd-service
+    newTag: v1.0.0
+  - name: ghcr.io/rohianon/equishare-notification-service
+    newTag: v1.0.0
+  - name: ghcr.io/rohianon/equishare-market-data-service
+    newTag: v1.0.0
+  - name: ghcr.io/rohianon/equishare-portfolio-service
+    newTag: v1.0.0

--- a/infrastructure/k8s/production/pdb.yaml
+++ b/infrastructure/k8s/production/pdb.yaml
@@ -1,0 +1,107 @@
+---
+# API Gateway PDB - Critical for availability
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: api-gateway-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: api-gateway
+
+---
+# Auth Service PDB
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: auth-service-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: auth-service
+
+---
+# Trading Service PDB - Critical for order execution
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: trading-service-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: trading-service
+
+---
+# Payment Service PDB - Critical for M-Pesa transactions
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: payment-service-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: payment-service
+
+---
+# Market Data Service PDB
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: market-data-service-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: market-data-service
+
+---
+# User Service PDB
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: user-service-pdb
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: user-service
+
+---
+# USSD Service PDB
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: ussd-service-pdb
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ussd-service
+
+---
+# Notification Service PDB
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: notification-service-pdb
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: notification-service
+
+---
+# Portfolio Service PDB
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: portfolio-service-pdb
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: portfolio-service

--- a/infrastructure/k8s/staging/kustomization.yaml
+++ b/infrastructure/k8s/staging/kustomization.yaml
@@ -1,0 +1,95 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: equishare-staging
+
+resources:
+  - ../base
+
+namePrefix: staging-
+
+commonLabels:
+  environment: staging
+
+configMapGenerator:
+  - name: equishare-config
+    literals:
+      - environment=staging
+      - database.host=postgres-staging.database.svc.cluster.local
+      - database.port=5432
+      - database.name=equishare_staging
+      - redis.host=redis-staging.cache.svc.cluster.local
+      - redis.port=6379
+      - kafka.brokers=kafka-staging.messaging.svc.cluster.local:9092
+      - telemetry.collector_url=http://jaeger.observability.svc.cluster.local:4317
+
+  - name: equishare-common-env
+    literals:
+      - EQUISHARE_SERVER_HOST=0.0.0.0
+      - EQUISHARE_ENV=staging
+      - EQUISHARE_DATABASE_HOST=postgres-staging.database.svc.cluster.local
+      - EQUISHARE_DATABASE_PORT=5432
+      - EQUISHARE_DATABASE_DATABASE=equishare_staging
+      - EQUISHARE_DATABASE_USER=equishare
+      - EQUISHARE_REDIS_HOST=redis-staging.cache.svc.cluster.local
+      - EQUISHARE_REDIS_PORT=6379
+      - EQUISHARE_KAFKA_BROKERS=kafka-staging.messaging.svc.cluster.local:9092
+      - EQUISHARE_TELEMETRY_ENABLED=true
+      - EQUISHARE_TELEMETRY_COLLECTOR_URL=http://jaeger.observability.svc.cluster.local:4317
+
+patches:
+  # Reduce replicas for staging
+  - target:
+      kind: Deployment
+    patch: |-
+      - op: replace
+        path: /spec/replicas
+        value: 1
+
+  # Reduce HPA min/max for staging
+  - target:
+      kind: HorizontalPodAutoscaler
+    patch: |-
+      - op: replace
+        path: /spec/minReplicas
+        value: 1
+      - op: replace
+        path: /spec/maxReplicas
+        value: 2
+
+  # Reduce resources for staging
+  - target:
+      kind: Deployment
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/requests/cpu
+        value: 50m
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/requests/memory
+        value: 64Mi
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/limits/cpu
+        value: 200m
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/limits/memory
+        value: 256Mi
+
+images:
+  - name: ghcr.io/rohianon/equishare-api-gateway
+    newTag: staging
+  - name: ghcr.io/rohianon/equishare-auth-service
+    newTag: staging
+  - name: ghcr.io/rohianon/equishare-user-service
+    newTag: staging
+  - name: ghcr.io/rohianon/equishare-trading-service
+    newTag: staging
+  - name: ghcr.io/rohianon/equishare-payment-service
+    newTag: staging
+  - name: ghcr.io/rohianon/equishare-ussd-service
+    newTag: staging
+  - name: ghcr.io/rohianon/equishare-notification-service
+    newTag: staging
+  - name: ghcr.io/rohianon/equishare-market-data-service
+    newTag: staging
+  - name: ghcr.io/rohianon/equishare-portfolio-service
+    newTag: staging


### PR DESCRIPTION
## Summary
- Add Kubernetes manifests for all 9 services using Kustomize
- Create staging and production overlays
- Configure auto-scaling, high availability, and security

## Structure
```
infrastructure/k8s/
├── base/           # Common resources (deployments, services, HPAs)
├── staging/        # Reduced resources, 1 replica
└── production/     # HA settings, PDBs, Ingress
```

## Services
| Service | Port | Prod Replicas | Resources |
|---------|------|---------------|-----------|
| api-gateway | 8000 | 2-5 | 100m-500m CPU |
| auth-service | 8001 | 2-3 | 100m-300m CPU |
| trading-service | 8003 | 2-5 | 200m-1000m CPU |
| payment-service | 8004 | 2-3 | 100m-500m CPU |
| market-data-service | 8007 | 2-4 | 200m-500m CPU |

## Features
- **Health probes**: Liveness, readiness, startup
- **HPA**: Auto-scale on CPU/memory (70% threshold)
- **PDB**: Minimum availability during updates
- **NetworkPolicies**: Restrict pod communication
- **Ingress**: TLS with cert-manager
- **Security**: Non-root, read-only filesystem, dropped capabilities

## Usage
```bash
# Deploy staging
kubectl apply -k infrastructure/k8s/staging/

# Deploy production
kubectl apply -k infrastructure/k8s/production/
```

## Test plan
- [x] `kubectl kustomize infrastructure/k8s/staging/` succeeds
- [x] `kubectl kustomize infrastructure/k8s/production/` succeeds
- [x] All services have deployment, service, and HPA
- [ ] Manual deployment test (requires cluster)

Closes #36