### PR TITLE
fix(events): use correct Event struct fields in handlers

### DIFF
--- a/services/payment-service/internal/handler/handler.go
+++ b/services/payment-service/internal/handler/handler.go
@@ -95,17 +95,17 @@ func (h *Handler) Deposit(c *fiber.Ctx) error {
 	}
 
 	if h.publisher != nil {
-		h.publisher.Publish(ctx, events.TopicPaymentInitiated, &events.Event{
-			EventType: events.EventTypePaymentInitiated,
-			Source:    "payment-service",
-			Payload: map[string]any{
+		h.publisher.Publish(ctx, events.TopicPaymentInitiated, events.NewEvent(
+			events.EventTypePaymentInitiated,
+			"payment-service",
+			map[string]any{
 				"user_id":             userID,
 				"wallet_id":           wallet.ID,
 				"amount":              req.Amount,
 				"currency":            "KES",
 				"checkout_request_id": stkResp.CheckoutRequestID,
 			},
-		})
+		))
 	}
 
 	logger.Info().
@@ -181,10 +181,10 @@ func (h *Handler) STKCallback(c *fiber.Ctx) error {
 				}
 
 				if h.publisher != nil {
-					h.publisher.Publish(ctx, events.TopicPaymentCompleted, &events.Event{
-						EventType: events.EventTypePaymentCompleted,
-						Source:    "payment-service",
-						Payload: map[string]any{
+					h.publisher.Publish(ctx, events.TopicPaymentCompleted, events.NewEvent(
+						events.EventTypePaymentCompleted,
+						"payment-service",
+						map[string]any{
 							"user_id":        mpesaTx.UserID,
 							"wallet_id":      wallet.ID,
 							"amount":         data.Amount,
@@ -192,7 +192,7 @@ func (h *Handler) STKCallback(c *fiber.Ctx) error {
 							"mpesa_receipt":  data.MpesaReceiptNo,
 							"transaction_id": tx.ID,
 						},
-					})
+					))
 				}
 
 				user, _ := h.userRepo.GetByID(ctx, mpesaTx.UserID)
@@ -211,17 +211,17 @@ func (h *Handler) STKCallback(c *fiber.Ctx) error {
 		}
 	} else {
 		if h.publisher != nil {
-			h.publisher.Publish(ctx, events.TopicPaymentFailed, &events.Event{
-				EventType: events.EventTypePaymentFailed,
-				Source:    "payment-service",
-				Payload: map[string]any{
+			h.publisher.Publish(ctx, events.TopicPaymentFailed, events.NewEvent(
+				events.EventTypePaymentFailed,
+				"payment-service",
+				map[string]any{
 					"user_id":             mpesaTx.UserID,
 					"amount":              mpesaTx.Amount,
 					"result_code":         data.ResultCode,
 					"result_desc":         data.ResultDesc,
 					"checkout_request_id": data.CheckoutRequestID,
 				},
-			})
+			))
 		}
 
 		logger.Info().

--- a/services/trading-service/internal/handler/handler.go
+++ b/services/trading-service/internal/handler/handler.go
@@ -165,18 +165,18 @@ func (h *Handler) PlaceOrder(c *fiber.Ctx) error {
 
 	// Publish order created event
 	if h.publisher != nil {
-		h.publisher.Publish(ctx, events.TopicOrderCreated, &events.Event{
-			Type:   "order.created",
-			Source: "trading-service",
-			Data: map[string]any{
-				"order_id":       order.ID,
-				"user_id":        userID,
-				"symbol":         req.Symbol,
-				"side":           req.Side,
-				"amount":         req.Amount,
+		h.publisher.Publish(ctx, events.TopicOrderCreated, events.NewEvent(
+			events.EventTypeOrderCreated,
+			"trading-service",
+			map[string]any{
+				"order_id":        order.ID,
+				"user_id":         userID,
+				"symbol":          req.Symbol,
+				"side":            req.Side,
+				"amount":          req.Amount,
 				"alpaca_order_id": alpacaOrder.ID,
 			},
-		})
+		))
 	}
 
 	logger.Info().
@@ -456,10 +456,10 @@ func (h *Handler) handleOrderFill(ctx context.Context, order *types.Order, alpac
 
 	// Publish event
 	if h.publisher != nil {
-		h.publisher.Publish(ctx, events.TopicOrderFilled, &events.Event{
-			Type:   "order.filled",
-			Source: "trading-service",
-			Data: map[string]any{
+		h.publisher.Publish(ctx, events.TopicOrderFilled, events.NewEvent(
+			events.EventTypeOrderFilled,
+			"trading-service",
+			map[string]any{
 				"order_id":         order.ID,
 				"user_id":          order.UserID,
 				"symbol":           order.Symbol,
@@ -467,7 +467,7 @@ func (h *Handler) handleOrderFill(ctx context.Context, order *types.Order, alpac
 				"filled_qty":       filledQty,
 				"filled_avg_price": filledAvgPrice,
 			},
-		})
+		))
 	}
 
 	logger.Info().


### PR DESCRIPTION
## Summary
- Fix compiler errors caused by using non-existent fields (`Type`, `Data`) in Event struct
- Update trading-service and payment-service handlers to use `events.NewEvent()` helper

## Changes
- **trading-service/handler.go**: 2 event publishes updated
- **payment-service/handler.go**: 3 event publishes updated

## Test plan
- [x] `go build ./services/trading-service/...` passes
- [x] `go build ./services/payment-service/...` passes

Closes #83