### PR TITLE
feat(market-data): implement Market Data Service with Alpaca integration

### DIFF
--- a/pkg/alpaca/interface.go
+++ b/pkg/alpaca/interface.go
@@ -28,6 +28,11 @@ type TradingClient interface {
 
 	// Market Data
 	GetQuote(ctx context.Context, symbol string) (*Quote, error)
+	GetMultiQuotes(ctx context.Context, symbols []string) (map[string]Quote, error)
+	GetBars(ctx context.Context, symbol string, params *GetBarsParams) ([]Bar, error)
+	GetClock(ctx context.Context) (*Clock, error)
+	GetCalendar(ctx context.Context, params *GetCalendarParams) ([]CalendarDay, error)
+	GetSnapshot(ctx context.Context, symbol string) (*Snapshot, error)
 }
 
 // Ensure Client and MockClient implement TradingClient

--- a/pkg/alpaca/marketdata.go
+++ b/pkg/alpaca/marketdata.go
@@ -1,0 +1,234 @@
+package alpaca
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// Bar represents OHLCV data for a time period
+type Bar struct {
+	Timestamp  time.Time `json:"t"`
+	Open       float64   `json:"o"`
+	High       float64   `json:"h"`
+	Low        float64   `json:"l"`
+	Close      float64   `json:"c"`
+	Volume     uint64    `json:"v"`
+	TradeCount uint64    `json:"n"`
+	VWAP       float64   `json:"vw"`
+}
+
+// BarsResponse represents the response from the bars endpoint
+type BarsResponse struct {
+	Bars          map[string][]Bar `json:"bars"`
+	NextPageToken string           `json:"next_page_token,omitempty"`
+}
+
+// GetBarsParams contains parameters for fetching historical bars
+type GetBarsParams struct {
+	Timeframe string    // 1Min, 5Min, 15Min, 1Hour, 1Day, 1Week, 1Month
+	Start     time.Time // Start of time range
+	End       time.Time // End of time range (optional, defaults to now)
+	Limit     int       // Max number of bars (default 1000, max 10000)
+	Feed      string    // iex, sip (default: iex for free tier)
+}
+
+// GetBars retrieves historical bars for a symbol
+func (c *Client) GetBars(ctx context.Context, symbol string, params *GetBarsParams) ([]Bar, error) {
+	if params == nil {
+		params = &GetBarsParams{
+			Timeframe: "1Day",
+			Limit:     100,
+		}
+	}
+
+	if params.Timeframe == "" {
+		params.Timeframe = "1Day"
+	}
+	if params.Limit == 0 {
+		params.Limit = 100
+	}
+	if params.Feed == "" {
+		params.Feed = "iex"
+	}
+
+	query := url.Values{}
+	query.Set("timeframe", params.Timeframe)
+	query.Set("limit", fmt.Sprintf("%d", params.Limit))
+	query.Set("feed", params.Feed)
+
+	if !params.Start.IsZero() {
+		query.Set("start", params.Start.Format(time.RFC3339))
+	}
+	if !params.End.IsZero() {
+		query.Set("end", params.End.Format(time.RFC3339))
+	}
+
+	apiURL := fmt.Sprintf("%s/v2/stocks/%s/bars?%s", c.dataURL, symbol, query.Encode())
+	resp, err := c.doRequest(ctx, "GET", apiURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var result struct {
+		Bars          []Bar  `json:"bars"`
+		NextPageToken string `json:"next_page_token,omitempty"`
+	}
+	if err := decodeResponse(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return result.Bars, nil
+}
+
+// MultiQuotesResponse represents the response from multi-quotes endpoint
+type MultiQuotesResponse struct {
+	Quotes map[string]Quote `json:"quotes"`
+}
+
+// GetMultiQuotes retrieves quotes for multiple symbols
+func (c *Client) GetMultiQuotes(ctx context.Context, symbols []string) (map[string]Quote, error) {
+	if len(symbols) == 0 {
+		return make(map[string]Quote), nil
+	}
+
+	symbolsParam := strings.Join(symbols, ",")
+	apiURL := fmt.Sprintf("%s/v2/stocks/quotes/latest?symbols=%s&feed=iex", c.dataURL, url.QueryEscape(symbolsParam))
+
+	resp, err := c.doRequest(ctx, "GET", apiURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var result struct {
+		Quotes map[string]struct {
+			AskPrice  float64   `json:"ap"`
+			AskSize   int       `json:"as"`
+			BidPrice  float64   `json:"bp"`
+			BidSize   int       `json:"bs"`
+			Timestamp time.Time `json:"t"`
+		} `json:"quotes"`
+	}
+	if err := decodeResponse(resp, &result); err != nil {
+		return nil, err
+	}
+
+	// Convert to our Quote type
+	quotes := make(map[string]Quote)
+	for symbol, q := range result.Quotes {
+		quotes[symbol] = Quote{
+			Symbol:    symbol,
+			AskPrice:  q.AskPrice,
+			AskSize:   q.AskSize,
+			BidPrice:  q.BidPrice,
+			BidSize:   q.BidSize,
+			Timestamp: q.Timestamp.Format(time.RFC3339),
+		}
+	}
+
+	return quotes, nil
+}
+
+// Clock represents market clock information
+type Clock struct {
+	Timestamp time.Time `json:"timestamp"`
+	IsOpen    bool      `json:"is_open"`
+	NextOpen  time.Time `json:"next_open"`
+	NextClose time.Time `json:"next_close"`
+}
+
+// GetClock retrieves the current market clock
+func (c *Client) GetClock(ctx context.Context) (*Clock, error) {
+	apiURL := fmt.Sprintf("%s/v2/clock", c.baseURL)
+	resp, err := c.doRequest(ctx, "GET", apiURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var clock Clock
+	if err := decodeResponse(resp, &clock); err != nil {
+		return nil, err
+	}
+
+	return &clock, nil
+}
+
+// CalendarDay represents a single trading day
+type CalendarDay struct {
+	Date  string `json:"date"`
+	Open  string `json:"open"`
+	Close string `json:"close"`
+}
+
+// GetCalendarParams contains parameters for fetching calendar
+type GetCalendarParams struct {
+	Start string // YYYY-MM-DD format
+	End   string // YYYY-MM-DD format
+}
+
+// GetCalendar retrieves the market calendar
+func (c *Client) GetCalendar(ctx context.Context, params *GetCalendarParams) ([]CalendarDay, error) {
+	apiURL := fmt.Sprintf("%s/v2/calendar", c.baseURL)
+
+	if params != nil {
+		query := url.Values{}
+		if params.Start != "" {
+			query.Set("start", params.Start)
+		}
+		if params.End != "" {
+			query.Set("end", params.End)
+		}
+		if len(query) > 0 {
+			apiURL += "?" + query.Encode()
+		}
+	}
+
+	resp, err := c.doRequest(ctx, "GET", apiURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var calendar []CalendarDay
+	if err := decodeResponse(resp, &calendar); err != nil {
+		return nil, err
+	}
+
+	return calendar, nil
+}
+
+// Snapshot represents a complete market snapshot for a symbol
+type Snapshot struct {
+	LatestTrade  *Trade `json:"latestTrade,omitempty"`
+	LatestQuote  *Quote `json:"latestQuote,omitempty"`
+	MinuteBar    *Bar   `json:"minuteBar,omitempty"`
+	DailyBar     *Bar   `json:"dailyBar,omitempty"`
+	PrevDailyBar *Bar   `json:"prevDailyBar,omitempty"`
+}
+
+// Trade represents a single trade
+type Trade struct {
+	Timestamp time.Time `json:"t"`
+	Price     float64   `json:"p"`
+	Size      uint64    `json:"s"`
+	Exchange  string    `json:"x"`
+	ID        uint64    `json:"i"`
+	Tape      string    `json:"z"`
+}
+
+// GetSnapshot retrieves a complete snapshot for a symbol
+func (c *Client) GetSnapshot(ctx context.Context, symbol string) (*Snapshot, error) {
+	apiURL := fmt.Sprintf("%s/v2/stocks/%s/snapshot?feed=iex", c.dataURL, symbol)
+	resp, err := c.doRequest(ctx, "GET", apiURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var snapshot Snapshot
+	if err := decodeResponse(resp, &snapshot); err != nil {
+		return nil, err
+	}
+
+	return &snapshot, nil
+}

--- a/services/market-data-service/internal/handler/handler.go
+++ b/services/market-data-service/internal/handler/handler.go
@@ -1,0 +1,471 @@
+package handler
+
+import (
+	"strings"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/Rohianon/equishare-global-trading/pkg/alpaca"
+	"github.com/Rohianon/equishare-global-trading/pkg/logger"
+	"github.com/Rohianon/equishare-global-trading/services/market-data-service/internal/types"
+)
+
+// Handler handles market data HTTP requests
+type Handler struct {
+	alpaca alpaca.TradingClient
+}
+
+// NewHandler creates a new market data handler
+func NewHandler(alpacaClient alpaca.TradingClient) *Handler {
+	return &Handler{
+		alpaca: alpacaClient,
+	}
+}
+
+// GetQuote retrieves the latest quote for a symbol
+// GET /quotes/:symbol
+func (h *Handler) GetQuote(c *fiber.Ctx) error {
+	symbol := strings.ToUpper(c.Params("symbol"))
+	if symbol == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(types.ErrorResponse{
+			Error:   "bad_request",
+			Message: "Symbol is required",
+			Code:    400,
+		})
+	}
+
+	ctx := c.Context()
+
+	quote, err := h.alpaca.GetQuote(ctx, symbol)
+	if err != nil {
+		logger.Error().Err(err).Str("symbol", symbol).Msg("Failed to fetch quote")
+		return c.Status(fiber.StatusInternalServerError).JSON(types.ErrorResponse{
+			Error:   "internal_error",
+			Message: "Failed to fetch quote",
+			Code:    500,
+		})
+	}
+
+	midPrice := (quote.BidPrice + quote.AskPrice) / 2
+	spread := quote.AskPrice - quote.BidPrice
+
+	return c.JSON(types.QuoteResponse{
+		Symbol:    symbol,
+		BidPrice:  quote.BidPrice,
+		BidSize:   quote.BidSize,
+		AskPrice:  quote.AskPrice,
+		AskSize:   quote.AskSize,
+		MidPrice:  midPrice,
+		Spread:    spread,
+		Timestamp: quote.Timestamp,
+	})
+}
+
+// GetMultiQuotes retrieves quotes for multiple symbols
+// GET /quotes?symbols=AAPL,GOOGL,MSFT
+func (h *Handler) GetMultiQuotes(c *fiber.Ctx) error {
+	symbolsParam := c.Query("symbols")
+	if symbolsParam == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(types.ErrorResponse{
+			Error:   "bad_request",
+			Message: "Symbols query parameter is required",
+			Code:    400,
+		})
+	}
+
+	symbols := strings.Split(strings.ToUpper(symbolsParam), ",")
+	if len(symbols) > 100 {
+		return c.Status(fiber.StatusBadRequest).JSON(types.ErrorResponse{
+			Error:   "bad_request",
+			Message: "Maximum 100 symbols allowed",
+			Code:    400,
+		})
+	}
+
+	// Clean up symbols
+	cleanSymbols := make([]string, 0, len(symbols))
+	for _, s := range symbols {
+		s = strings.TrimSpace(s)
+		if s != "" {
+			cleanSymbols = append(cleanSymbols, s)
+		}
+	}
+
+	ctx := c.Context()
+
+	quotes, err := h.alpaca.GetMultiQuotes(ctx, cleanSymbols)
+	if err != nil {
+		logger.Error().Err(err).Strs("symbols", cleanSymbols).Msg("Failed to fetch multi quotes")
+		return c.Status(fiber.StatusInternalServerError).JSON(types.ErrorResponse{
+			Error:   "internal_error",
+			Message: "Failed to fetch quotes",
+			Code:    500,
+		})
+	}
+
+	response := types.MultiQuoteResponse{
+		Quotes: make(map[string]types.QuoteResponse),
+	}
+
+	for symbol, q := range quotes {
+		midPrice := (q.BidPrice + q.AskPrice) / 2
+		spread := q.AskPrice - q.BidPrice
+		response.Quotes[symbol] = types.QuoteResponse{
+			Symbol:    symbol,
+			BidPrice:  q.BidPrice,
+			BidSize:   q.BidSize,
+			AskPrice:  q.AskPrice,
+			AskSize:   q.AskSize,
+			MidPrice:  midPrice,
+			Spread:    spread,
+			Timestamp: q.Timestamp,
+		}
+	}
+
+	return c.JSON(response)
+}
+
+// GetBars retrieves historical OHLCV bars for a symbol
+// GET /bars/:symbol?timeframe=1Day&start=2024-01-01&end=2024-12-31&limit=100
+func (h *Handler) GetBars(c *fiber.Ctx) error {
+	symbol := strings.ToUpper(c.Params("symbol"))
+	if symbol == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(types.ErrorResponse{
+			Error:   "bad_request",
+			Message: "Symbol is required",
+			Code:    400,
+		})
+	}
+
+	timeframe := c.Query("timeframe", "1Day")
+	startStr := c.Query("start")
+	endStr := c.Query("end")
+	limit := c.QueryInt("limit", 100)
+
+	if limit > 10000 {
+		limit = 10000
+	}
+
+	params := &alpaca.GetBarsParams{
+		Timeframe: timeframe,
+		Limit:     limit,
+	}
+
+	if startStr != "" {
+		start, err := parseTime(startStr)
+		if err != nil {
+			return c.Status(fiber.StatusBadRequest).JSON(types.ErrorResponse{
+				Error:   "bad_request",
+				Message: "Invalid start date format. Use RFC3339 or YYYY-MM-DD",
+				Code:    400,
+			})
+		}
+		params.Start = start
+	}
+
+	if endStr != "" {
+		end, err := parseTime(endStr)
+		if err != nil {
+			return c.Status(fiber.StatusBadRequest).JSON(types.ErrorResponse{
+				Error:   "bad_request",
+				Message: "Invalid end date format. Use RFC3339 or YYYY-MM-DD",
+				Code:    400,
+			})
+		}
+		params.End = end
+	}
+
+	ctx := c.Context()
+
+	bars, err := h.alpaca.GetBars(ctx, symbol, params)
+	if err != nil {
+		logger.Error().Err(err).Str("symbol", symbol).Msg("Failed to fetch bars")
+		return c.Status(fiber.StatusInternalServerError).JSON(types.ErrorResponse{
+			Error:   "internal_error",
+			Message: "Failed to fetch historical data",
+			Code:    500,
+		})
+	}
+
+	response := types.BarsResponse{
+		Symbol: symbol,
+		Bars:   make([]types.BarResponse, len(bars)),
+	}
+
+	for i, bar := range bars {
+		response.Bars[i] = types.BarResponse{
+			Timestamp:  bar.Timestamp,
+			Open:       bar.Open,
+			High:       bar.High,
+			Low:        bar.Low,
+			Close:      bar.Close,
+			Volume:     bar.Volume,
+			TradeCount: bar.TradeCount,
+			VWAP:       bar.VWAP,
+		}
+	}
+
+	return c.JSON(response)
+}
+
+// GetAsset retrieves asset information by symbol
+// GET /assets/:symbol
+func (h *Handler) GetAsset(c *fiber.Ctx) error {
+	symbol := strings.ToUpper(c.Params("symbol"))
+	if symbol == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(types.ErrorResponse{
+			Error:   "bad_request",
+			Message: "Symbol is required",
+			Code:    400,
+		})
+	}
+
+	ctx := c.Context()
+
+	asset, err := h.alpaca.GetAsset(ctx, symbol)
+	if err != nil {
+		logger.Error().Err(err).Str("symbol", symbol).Msg("Failed to fetch asset")
+		return c.Status(fiber.StatusNotFound).JSON(types.ErrorResponse{
+			Error:   "not_found",
+			Message: "Asset not found",
+			Code:    404,
+		})
+	}
+
+	return c.JSON(types.AssetResponse{
+		ID:           asset.ID,
+		Symbol:       asset.Symbol,
+		Name:         asset.Name,
+		Exchange:     asset.Exchange,
+		Class:        asset.Class,
+		Status:       asset.Status,
+		Tradable:     asset.Tradable,
+		Fractionable: asset.Fractionable,
+		Marginable:   asset.Marginable,
+		Shortable:    asset.Shortable,
+	})
+}
+
+// SearchAssets searches for tradeable assets
+// GET /assets/search?q=apple&class=us_equity&status=active&limit=20
+func (h *Handler) SearchAssets(c *fiber.Ctx) error {
+	query := strings.ToUpper(c.Query("q"))
+	class := c.Query("class", "us_equity")
+	status := c.Query("status", "active")
+	limit := c.QueryInt("limit", 20)
+
+	if limit > 100 {
+		limit = 100
+	}
+
+	ctx := c.Context()
+
+	params := &alpaca.ListAssetsParams{
+		Status:     status,
+		AssetClass: class,
+	}
+
+	assets, err := h.alpaca.ListAssets(ctx, params)
+	if err != nil {
+		logger.Error().Err(err).Msg("Failed to list assets")
+		return c.Status(fiber.StatusInternalServerError).JSON(types.ErrorResponse{
+			Error:   "internal_error",
+			Message: "Failed to search assets",
+			Code:    500,
+		})
+	}
+
+	// Filter by query if provided
+	filtered := make([]types.AssetResponse, 0)
+	for _, asset := range assets {
+		if query != "" {
+			symbolMatch := strings.Contains(strings.ToUpper(asset.Symbol), query)
+			nameMatch := strings.Contains(strings.ToUpper(asset.Name), query)
+			if !symbolMatch && !nameMatch {
+				continue
+			}
+		}
+
+		filtered = append(filtered, types.AssetResponse{
+			ID:           asset.ID,
+			Symbol:       asset.Symbol,
+			Name:         asset.Name,
+			Exchange:     asset.Exchange,
+			Class:        asset.Class,
+			Status:       asset.Status,
+			Tradable:     asset.Tradable,
+			Fractionable: asset.Fractionable,
+			Marginable:   asset.Marginable,
+			Shortable:    asset.Shortable,
+		})
+
+		if len(filtered) >= limit {
+			break
+		}
+	}
+
+	return c.JSON(types.AssetSearchResponse{
+		Assets: filtered,
+		Total:  len(filtered),
+	})
+}
+
+// GetClock retrieves the current market clock
+// GET /market/clock
+func (h *Handler) GetClock(c *fiber.Ctx) error {
+	ctx := c.Context()
+
+	clock, err := h.alpaca.GetClock(ctx)
+	if err != nil {
+		logger.Error().Err(err).Msg("Failed to fetch market clock")
+		return c.Status(fiber.StatusInternalServerError).JSON(types.ErrorResponse{
+			Error:   "internal_error",
+			Message: "Failed to fetch market clock",
+			Code:    500,
+		})
+	}
+
+	return c.JSON(types.ClockResponse{
+		Timestamp: clock.Timestamp.Format(time.RFC3339),
+		IsOpen:    clock.IsOpen,
+		NextOpen:  clock.NextOpen.Format(time.RFC3339),
+		NextClose: clock.NextClose.Format(time.RFC3339),
+	})
+}
+
+// GetCalendar retrieves the market calendar
+// GET /market/calendar?start=2024-01-01&end=2024-12-31
+func (h *Handler) GetCalendar(c *fiber.Ctx) error {
+	start := c.Query("start")
+	end := c.Query("end")
+
+	var params *alpaca.GetCalendarParams
+	if start != "" || end != "" {
+		params = &alpaca.GetCalendarParams{
+			Start: start,
+			End:   end,
+		}
+	}
+
+	ctx := c.Context()
+
+	calendar, err := h.alpaca.GetCalendar(ctx, params)
+	if err != nil {
+		logger.Error().Err(err).Msg("Failed to fetch market calendar")
+		return c.Status(fiber.StatusInternalServerError).JSON(types.ErrorResponse{
+			Error:   "internal_error",
+			Message: "Failed to fetch market calendar",
+			Code:    500,
+		})
+	}
+
+	days := make([]types.CalendarDayResponse, len(calendar))
+	for i, day := range calendar {
+		days[i] = types.CalendarDayResponse{
+			Date:  day.Date,
+			Open:  day.Open,
+			Close: day.Close,
+		}
+	}
+
+	return c.JSON(types.CalendarResponse{
+		Days: days,
+	})
+}
+
+// GetSnapshot retrieves a complete snapshot for a symbol
+// GET /snapshot/:symbol
+func (h *Handler) GetSnapshot(c *fiber.Ctx) error {
+	symbol := strings.ToUpper(c.Params("symbol"))
+	if symbol == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(types.ErrorResponse{
+			Error:   "bad_request",
+			Message: "Symbol is required",
+			Code:    400,
+		})
+	}
+
+	ctx := c.Context()
+
+	snapshot, err := h.alpaca.GetSnapshot(ctx, symbol)
+	if err != nil {
+		logger.Error().Err(err).Str("symbol", symbol).Msg("Failed to fetch snapshot")
+		return c.Status(fiber.StatusInternalServerError).JSON(types.ErrorResponse{
+			Error:   "internal_error",
+			Message: "Failed to fetch snapshot",
+			Code:    500,
+		})
+	}
+
+	response := types.SnapshotResponse{
+		Symbol: symbol,
+	}
+
+	if snapshot.LatestTrade != nil {
+		response.LatestTrade = &types.TradeInfo{
+			Timestamp: snapshot.LatestTrade.Timestamp.Format(time.RFC3339),
+			Price:     snapshot.LatestTrade.Price,
+			Size:      snapshot.LatestTrade.Size,
+			Exchange:  snapshot.LatestTrade.Exchange,
+		}
+	}
+
+	if snapshot.LatestQuote != nil {
+		midPrice := (snapshot.LatestQuote.BidPrice + snapshot.LatestQuote.AskPrice) / 2
+		spread := snapshot.LatestQuote.AskPrice - snapshot.LatestQuote.BidPrice
+		response.LatestQuote = &types.QuoteResponse{
+			Symbol:    symbol,
+			BidPrice:  snapshot.LatestQuote.BidPrice,
+			BidSize:   snapshot.LatestQuote.BidSize,
+			AskPrice:  snapshot.LatestQuote.AskPrice,
+			AskSize:   snapshot.LatestQuote.AskSize,
+			MidPrice:  midPrice,
+			Spread:    spread,
+			Timestamp: snapshot.LatestQuote.Timestamp,
+		}
+	}
+
+	if snapshot.MinuteBar != nil {
+		response.MinuteBar = barToResponse(snapshot.MinuteBar)
+	}
+	if snapshot.DailyBar != nil {
+		response.DailyBar = barToResponse(snapshot.DailyBar)
+	}
+	if snapshot.PrevDailyBar != nil {
+		response.PrevDailyBar = barToResponse(snapshot.PrevDailyBar)
+	}
+
+	return c.JSON(response)
+}
+
+// Helper functions
+
+func parseTime(s string) (time.Time, error) {
+	// Try RFC3339 first
+	t, err := time.Parse(time.RFC3339, s)
+	if err == nil {
+		return t, nil
+	}
+
+	// Try date only format
+	t, err = time.Parse("2006-01-02", s)
+	if err == nil {
+		return t, nil
+	}
+
+	return time.Time{}, err
+}
+
+func barToResponse(bar *alpaca.Bar) *types.BarResponse {
+	return &types.BarResponse{
+		Timestamp:  bar.Timestamp,
+		Open:       bar.Open,
+		High:       bar.High,
+		Low:        bar.Low,
+		Close:      bar.Close,
+		Volume:     bar.Volume,
+		TradeCount: bar.TradeCount,
+		VWAP:       bar.VWAP,
+	}
+}

--- a/services/market-data-service/internal/types/types.go
+++ b/services/market-data-service/internal/types/types.go
@@ -1,0 +1,130 @@
+package types
+
+import "time"
+
+// QuoteResponse represents a single stock quote
+type QuoteResponse struct {
+	Symbol    string  `json:"symbol"`
+	BidPrice  float64 `json:"bid_price"`
+	BidSize   int     `json:"bid_size"`
+	AskPrice  float64 `json:"ask_price"`
+	AskSize   int     `json:"ask_size"`
+	MidPrice  float64 `json:"mid_price"`
+	Spread    float64 `json:"spread"`
+	Timestamp string  `json:"timestamp"`
+}
+
+// MultiQuoteRequest represents a request for multiple quotes
+type MultiQuoteRequest struct {
+	Symbols []string `json:"symbols" query:"symbols"`
+}
+
+// MultiQuoteResponse represents quotes for multiple symbols
+type MultiQuoteResponse struct {
+	Quotes map[string]QuoteResponse `json:"quotes"`
+}
+
+// BarResponse represents a single OHLCV bar
+type BarResponse struct {
+	Timestamp  time.Time `json:"timestamp"`
+	Open       float64   `json:"open"`
+	High       float64   `json:"high"`
+	Low        float64   `json:"low"`
+	Close      float64   `json:"close"`
+	Volume     uint64    `json:"volume"`
+	TradeCount uint64    `json:"trade_count"`
+	VWAP       float64   `json:"vwap"`
+}
+
+// BarsRequest represents parameters for fetching bars
+type BarsRequest struct {
+	Timeframe string `json:"timeframe" query:"timeframe"` // 1Min, 5Min, 15Min, 1Hour, 1Day
+	Start     string `json:"start" query:"start"`         // RFC3339 or YYYY-MM-DD
+	End       string `json:"end" query:"end"`             // RFC3339 or YYYY-MM-DD
+	Limit     int    `json:"limit" query:"limit"`         // Max 10000
+}
+
+// BarsResponse represents historical bars
+type BarsResponse struct {
+	Symbol string        `json:"symbol"`
+	Bars   []BarResponse `json:"bars"`
+}
+
+// AssetResponse represents asset information
+type AssetResponse struct {
+	ID           string `json:"id"`
+	Symbol       string `json:"symbol"`
+	Name         string `json:"name"`
+	Exchange     string `json:"exchange"`
+	Class        string `json:"class"`
+	Status       string `json:"status"`
+	Tradable     bool   `json:"tradable"`
+	Fractionable bool   `json:"fractionable"`
+	Marginable   bool   `json:"marginable"`
+	Shortable    bool   `json:"shortable"`
+}
+
+// AssetSearchRequest represents search parameters
+type AssetSearchRequest struct {
+	Query  string `json:"query" query:"q"`
+	Class  string `json:"class" query:"class"`   // us_equity, crypto
+	Status string `json:"status" query:"status"` // active, inactive
+	Limit  int    `json:"limit" query:"limit"`
+}
+
+// AssetSearchResponse represents search results
+type AssetSearchResponse struct {
+	Assets []AssetResponse `json:"assets"`
+	Total  int             `json:"total"`
+}
+
+// ClockResponse represents market clock status
+type ClockResponse struct {
+	Timestamp string `json:"timestamp"`
+	IsOpen    bool   `json:"is_open"`
+	NextOpen  string `json:"next_open"`
+	NextClose string `json:"next_close"`
+}
+
+// CalendarDayResponse represents a trading day
+type CalendarDayResponse struct {
+	Date  string `json:"date"`
+	Open  string `json:"open"`
+	Close string `json:"close"`
+}
+
+// CalendarRequest represents calendar query parameters
+type CalendarRequest struct {
+	Start string `json:"start" query:"start"` // YYYY-MM-DD
+	End   string `json:"end" query:"end"`     // YYYY-MM-DD
+}
+
+// CalendarResponse represents market calendar
+type CalendarResponse struct {
+	Days []CalendarDayResponse `json:"days"`
+}
+
+// SnapshotResponse represents a complete market snapshot
+type SnapshotResponse struct {
+	Symbol      string        `json:"symbol"`
+	LatestTrade *TradeInfo    `json:"latest_trade,omitempty"`
+	LatestQuote *QuoteResponse `json:"latest_quote,omitempty"`
+	MinuteBar   *BarResponse  `json:"minute_bar,omitempty"`
+	DailyBar    *BarResponse  `json:"daily_bar,omitempty"`
+	PrevDailyBar *BarResponse `json:"prev_daily_bar,omitempty"`
+}
+
+// TradeInfo represents a single trade
+type TradeInfo struct {
+	Timestamp string  `json:"timestamp"`
+	Price     float64 `json:"price"`
+	Size      uint64  `json:"size"`
+	Exchange  string  `json:"exchange"`
+}
+
+// ErrorResponse represents an API error
+type ErrorResponse struct {
+	Error   string `json:"error"`
+	Message string `json:"message"`
+	Code    int    `json:"code"`
+}

--- a/services/market-data-service/main.go
+++ b/services/market-data-service/main.go
@@ -8,30 +8,100 @@ import (
 	"syscall"
 
 	"github.com/gofiber/fiber/v2"
+	"github.com/gofiber/fiber/v2/middleware/cors"
 	"github.com/gofiber/fiber/v2/middleware/recover"
 
+	"github.com/Rohianon/equishare-global-trading/pkg/alpaca"
 	"github.com/Rohianon/equishare-global-trading/pkg/logger"
 	"github.com/Rohianon/equishare-global-trading/pkg/middleware"
+	"github.com/Rohianon/equishare-global-trading/services/market-data-service/internal/handler"
 )
 
 func main() {
 	logger.Init("market-data-service", "info", true)
 	logger.Info().Msg("Starting Market Data Service")
 
-	app := fiber.New(fiber.Config{AppName: "EquiShare Market Data Service"})
-	app.Use(recover.New())
-	app.Use(middleware.RequestID())
+	// Alpaca client
+	var alpacaClient alpaca.TradingClient
+	alpacaAPIKey := os.Getenv("ALPACA_API_KEY")
+	alpacaSecretKey := os.Getenv("ALPACA_SECRET_KEY")
+	alpacaPaper := os.Getenv("ALPACA_PAPER") != "false" // Default to paper trading
 
-	app.Get("/health", func(c *fiber.Ctx) error {
-		return c.JSON(fiber.Map{"status": "healthy", "service": "market-data-service"})
+	if alpacaAPIKey == "" {
+		logger.Warn().Msg("Using mock Alpaca client (no API key configured)")
+		alpacaClient = alpaca.NewMockClient()
+	} else {
+		alpacaClient = alpaca.NewClient(&alpaca.Config{
+			APIKey:    alpacaAPIKey,
+			SecretKey: alpacaSecretKey,
+			Paper:     alpacaPaper,
+		})
+		logger.Info().Bool("paper", alpacaPaper).Msg("Connected to Alpaca")
+	}
+
+	// Initialize handler
+	h := handler.NewHandler(alpacaClient)
+
+	// Setup Fiber app
+	app := fiber.New(fiber.Config{
+		AppName:      "EquiShare Market Data Service",
+		ErrorHandler: customErrorHandler,
 	})
 
+	// Middleware
+	app.Use(recover.New())
+	app.Use(middleware.RequestID())
+	app.Use(cors.New(cors.Config{
+		AllowOrigins: "*",
+		AllowHeaders: "Origin, Content-Type, Accept, Authorization",
+		AllowMethods: "GET, POST, OPTIONS",
+	}))
+
+	// Health check
+	app.Get("/health", func(c *fiber.Ctx) error {
+		return c.JSON(fiber.Map{
+			"status":  "healthy",
+			"service": "market-data-service",
+		})
+	})
+
+	// API routes
+	api := app.Group("/api/v1")
+
+	// Quote endpoints
+	api.Get("/quotes", h.GetMultiQuotes)       // GET /api/v1/quotes?symbols=AAPL,GOOGL
+	api.Get("/quotes/:symbol", h.GetQuote)     // GET /api/v1/quotes/AAPL
+
+	// Historical data
+	api.Get("/bars/:symbol", h.GetBars)        // GET /api/v1/bars/AAPL?timeframe=1Day&limit=100
+
+	// Asset endpoints
+	api.Get("/assets/search", h.SearchAssets)  // GET /api/v1/assets/search?q=apple
+	api.Get("/assets/:symbol", h.GetAsset)     // GET /api/v1/assets/AAPL
+
+	// Market status
+	api.Get("/market/clock", h.GetClock)       // GET /api/v1/market/clock
+	api.Get("/market/calendar", h.GetCalendar) // GET /api/v1/market/calendar
+
+	// Snapshot (combined data)
+	api.Get("/snapshot/:symbol", h.GetSnapshot) // GET /api/v1/snapshot/AAPL
+
+	// Get port from environment or use default
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8007"
+	}
+
+	// Start server
 	go func() {
-		if err := app.Listen(":8007"); err != nil && !errors.Is(err, net.ErrClosed) {
+		addr := ":" + port
+		logger.Info().Str("addr", addr).Msg("Server listening")
+		if err := app.Listen(addr); err != nil && !errors.Is(err, net.ErrClosed) {
 			logger.Fatal().Err(err).Msg("Failed to start server")
 		}
 	}()
 
+	// Graceful shutdown
 	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
 	<-quit
@@ -40,4 +110,22 @@ func main() {
 	if err := app.Shutdown(); err != nil {
 		logger.Error().Err(err).Msg("Error during shutdown")
 	}
+}
+
+func customErrorHandler(c *fiber.Ctx, err error) error {
+	code := fiber.StatusInternalServerError
+	message := "Internal Server Error"
+
+	var e *fiber.Error
+	if errors.As(err, &e) {
+		code = e.Code
+		message = e.Message
+	}
+
+	logger.Error().Err(err).Int("status", code).Msg("Request error")
+
+	return c.Status(code).JSON(fiber.Map{
+		"error":   message,
+		"code":    code,
+	})
 }


### PR DESCRIPTION
## Summary
- Implement fully functional Market Data Service
- Extend Alpaca client with market data methods
- Add mock client implementations for testing

## Endpoints Added
| Endpoint | Description |
|----------|-------------|
| `GET /api/v1/quotes/:symbol` | Get latest quote |
| `GET /api/v1/quotes?symbols=...` | Batch quotes |
| `GET /api/v1/bars/:symbol` | Historical OHLCV bars |
| `GET /api/v1/assets/:symbol` | Asset information |
| `GET /api/v1/assets/search?q=...` | Search assets |
| `GET /api/v1/market/clock` | Market open/close status |
| `GET /api/v1/market/calendar` | Trading calendar |
| `GET /api/v1/snapshot/:symbol` | Combined snapshot |

## Alpaca Client Extensions
- `GetBars()` - Historical data
- `GetMultiQuotes()` - Batch quotes
- `GetClock()` - Market status
- `GetCalendar()` - Market calendar
- `GetSnapshot()` - Combined data

## Test plan
- [x] `go build ./services/market-data-service/...` passes
- [x] `go build ./pkg/alpaca/...` passes
- [x] `go test ./pkg/alpaca/...` passes
- [x] All other services still build

Closes #85