### PR TITLE
feat(mobile): implement trading UI with stock detail and orders

### DIFF
--- a/mobile/app/(tabs)/_layout.tsx
+++ b/mobile/app/(tabs)/_layout.tsx
@@ -53,6 +53,15 @@ export default function TabsLayout() {
         }}
       />
       <Tabs.Screen
+        name="orders"
+        options={{
+          title: 'Orders',
+          tabBarIcon: ({ focused }) => (
+            <TabIcon focused={focused} icon="📋" label="Orders" />
+          ),
+        }}
+      />
+      <Tabs.Screen
         name="settings"
         options={{
           title: 'Settings',

--- a/mobile/app/(tabs)/orders.tsx
+++ b/mobile/app/(tabs)/orders.tsx
@@ -1,0 +1,442 @@
+import { useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  FlatList,
+  TouchableOpacity,
+  RefreshControl,
+  Alert,
+  ActivityIndicator,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { router } from 'expo-router';
+import { tradingApi } from '../../src/api/trading';
+import type { Order } from '../../src/types';
+
+type StatusFilter = '' | 'pending' | 'filled' | 'canceled';
+
+export default function OrdersScreen() {
+  const queryClient = useQueryClient();
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('');
+  const [cancellingId, setCancellingId] = useState<string | null>(null);
+
+  const { data, isLoading, refetch } = useQuery({
+    queryKey: ['orders', statusFilter],
+    queryFn: () => tradingApi.getOrders(statusFilter || undefined),
+    refetchInterval: 10000,
+  });
+
+  const cancelMutation = useMutation({
+    mutationFn: tradingApi.cancelOrder,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['orders'] });
+      queryClient.invalidateQueries({ queryKey: ['walletBalance'] });
+      setCancellingId(null);
+      Alert.alert('Order Cancelled', 'Your order has been cancelled successfully.');
+    },
+    onError: (error: any) => {
+      setCancellingId(null);
+      Alert.alert(
+        'Cancel Failed',
+        error.response?.data?.message || 'Failed to cancel order'
+      );
+    },
+  });
+
+  const handleCancel = (orderId: string) => {
+    Alert.alert('Cancel Order', 'Are you sure you want to cancel this order?', [
+      { text: 'No', style: 'cancel' },
+      {
+        text: 'Yes, Cancel',
+        style: 'destructive',
+        onPress: () => {
+          setCancellingId(orderId);
+          cancelMutation.mutate(orderId);
+        },
+      },
+    ]);
+  };
+
+  const formatCurrency = (value: number) => {
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: 'USD',
+    }).format(value);
+  };
+
+  const formatDate = (dateString: string) => {
+    return new Date(dateString).toLocaleString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  };
+
+  const getStatusStyle = (status: string) => {
+    switch (status.toLowerCase()) {
+      case 'new':
+      case 'pending':
+        return styles.statusPending;
+      case 'filled':
+        return styles.statusFilled;
+      case 'partial_fill':
+        return styles.statusPartial;
+      case 'canceled':
+        return styles.statusCanceled;
+      case 'failed':
+        return styles.statusFailed;
+      default:
+        return styles.statusDefault;
+    }
+  };
+
+  const canCancel = (status: string) => {
+    return ['new', 'pending'].includes(status.toLowerCase());
+  };
+
+  const orders = data?.orders || [];
+
+  const filters: { label: string; value: StatusFilter }[] = [
+    { label: 'All', value: '' },
+    { label: 'Pending', value: 'pending' },
+    { label: 'Filled', value: 'filled' },
+    { label: 'Canceled', value: 'canceled' },
+  ];
+
+  const renderOrder = ({ item }: { item: Order }) => (
+    <TouchableOpacity
+      style={styles.orderCard}
+      onPress={() => router.push({ pathname: '/stock/[symbol]', params: { symbol: item.symbol } })}
+    >
+      <View style={styles.orderHeader}>
+        <View>
+          <View style={styles.symbolRow}>
+            <Text style={styles.orderSymbol}>{item.symbol}</Text>
+            <View style={[styles.sideBadge, item.side === 'buy' ? styles.buyBadge : styles.sellBadge]}>
+              <Text style={styles.sideText}>{item.side.toUpperCase()}</Text>
+            </View>
+          </View>
+          <Text style={styles.orderDate}>{formatDate(item.created_at)}</Text>
+        </View>
+        <View style={[styles.statusBadge, getStatusStyle(item.status)]}>
+          <Text style={styles.statusText}>{item.status.replace('_', ' ')}</Text>
+        </View>
+      </View>
+
+      <View style={styles.orderDetails}>
+        <View style={styles.detailRow}>
+          <Text style={styles.detailLabel}>Amount</Text>
+          <Text style={styles.detailValue}>
+            {item.quantity > 0 ? `${item.quantity.toFixed(6)} shares` : '---'}
+          </Text>
+        </View>
+        {item.filled_quantity > 0 && (
+          <View style={styles.detailRow}>
+            <Text style={styles.detailLabel}>Filled</Text>
+            <Text style={styles.detailValue}>{item.filled_quantity.toFixed(6)} shares</Text>
+          </View>
+        )}
+        {item.filled_avg_price && item.filled_avg_price > 0 && (
+          <View style={styles.detailRow}>
+            <Text style={styles.detailLabel}>Avg Price</Text>
+            <Text style={styles.detailValue}>{formatCurrency(item.filled_avg_price)}</Text>
+          </View>
+        )}
+      </View>
+
+      {canCancel(item.status) && (
+        <TouchableOpacity
+          style={styles.cancelButton}
+          onPress={() => handleCancel(item.id)}
+          disabled={cancellingId === item.id}
+        >
+          {cancellingId === item.id ? (
+            <ActivityIndicator size="small" color="#EF4444" />
+          ) : (
+            <Text style={styles.cancelText}>Cancel Order</Text>
+          )}
+        </TouchableOpacity>
+      )}
+    </TouchableOpacity>
+  );
+
+  return (
+    <SafeAreaView style={styles.container} edges={['top']}>
+      <View style={styles.header}>
+        <Text style={styles.title}>Orders</Text>
+        <TouchableOpacity
+          style={styles.newOrderButton}
+          onPress={() => router.push('/(tabs)/trade')}
+        >
+          <Text style={styles.newOrderText}>+ New Order</Text>
+        </TouchableOpacity>
+      </View>
+
+      {/* Filters */}
+      <View style={styles.filterContainer}>
+        {filters.map((filter) => (
+          <TouchableOpacity
+            key={filter.value}
+            style={[
+              styles.filterButton,
+              statusFilter === filter.value && styles.filterButtonActive,
+            ]}
+            onPress={() => setStatusFilter(filter.value)}
+          >
+            <Text
+              style={[
+                styles.filterText,
+                statusFilter === filter.value && styles.filterTextActive,
+              ]}
+            >
+              {filter.label}
+            </Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+
+      <FlatList
+        data={orders}
+        keyExtractor={(item) => item.id}
+        renderItem={renderOrder}
+        contentContainerStyle={styles.listContent}
+        refreshControl={
+          <RefreshControl refreshing={isLoading} onRefresh={refetch} />
+        }
+        ListEmptyComponent={
+          !isLoading ? (
+            <View style={styles.emptyState}>
+              <Text style={styles.emptyIcon}>📋</Text>
+              <Text style={styles.emptyTitle}>No orders found</Text>
+              <Text style={styles.emptyText}>
+                {statusFilter
+                  ? `No ${statusFilter} orders`
+                  : 'Place your first order to get started'}
+              </Text>
+              <TouchableOpacity
+                style={styles.emptyButton}
+                onPress={() => router.push('/(tabs)/trade')}
+              >
+                <Text style={styles.emptyButtonText}>Start Trading</Text>
+              </TouchableOpacity>
+            </View>
+          ) : null
+        }
+      />
+
+      {orders.length > 0 && (
+        <View style={styles.footer}>
+          <Text style={styles.footerText}>
+            Showing {orders.length} order{orders.length !== 1 ? 's' : ''}
+          </Text>
+        </View>
+      )}
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#F9FAFB',
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    padding: 20,
+    backgroundColor: '#fff',
+    borderBottomWidth: 1,
+    borderBottomColor: '#E5E7EB',
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    color: '#111827',
+  },
+  newOrderButton: {
+    backgroundColor: '#10B981',
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    borderRadius: 10,
+  },
+  newOrderText: {
+    color: '#fff',
+    fontWeight: '600',
+    fontSize: 14,
+  },
+  filterContainer: {
+    flexDirection: 'row',
+    padding: 16,
+    gap: 8,
+    backgroundColor: '#fff',
+  },
+  filterButton: {
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    borderRadius: 20,
+    backgroundColor: '#F3F4F6',
+  },
+  filterButtonActive: {
+    backgroundColor: '#10B981',
+  },
+  filterText: {
+    fontSize: 14,
+    fontWeight: '500',
+    color: '#6B7280',
+  },
+  filterTextActive: {
+    color: '#fff',
+  },
+  listContent: {
+    padding: 16,
+    gap: 12,
+  },
+  orderCard: {
+    backgroundColor: '#fff',
+    borderRadius: 16,
+    padding: 16,
+  },
+  orderHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'flex-start',
+    marginBottom: 12,
+  },
+  symbolRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  orderSymbol: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: '#111827',
+  },
+  sideBadge: {
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    borderRadius: 6,
+  },
+  buyBadge: {
+    backgroundColor: '#ECFDF5',
+  },
+  sellBadge: {
+    backgroundColor: '#FEF2F2',
+  },
+  sideText: {
+    fontSize: 11,
+    fontWeight: '600',
+  },
+  orderDate: {
+    fontSize: 13,
+    color: '#6B7280',
+    marginTop: 4,
+  },
+  statusBadge: {
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    borderRadius: 12,
+  },
+  statusText: {
+    fontSize: 12,
+    fontWeight: '600',
+    textTransform: 'capitalize',
+  },
+  statusPending: {
+    backgroundColor: '#FEF3C7',
+  },
+  statusFilled: {
+    backgroundColor: '#ECFDF5',
+  },
+  statusPartial: {
+    backgroundColor: '#D1FAE5',
+  },
+  statusCanceled: {
+    backgroundColor: '#F3F4F6',
+  },
+  statusFailed: {
+    backgroundColor: '#FEE2E2',
+  },
+  statusDefault: {
+    backgroundColor: '#F3F4F6',
+  },
+  orderDetails: {
+    borderTopWidth: 1,
+    borderTopColor: '#F3F4F6',
+    paddingTop: 12,
+    gap: 6,
+  },
+  detailRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
+  detailLabel: {
+    fontSize: 14,
+    color: '#6B7280',
+  },
+  detailValue: {
+    fontSize: 14,
+    fontWeight: '500',
+    color: '#111827',
+  },
+  cancelButton: {
+    marginTop: 12,
+    paddingVertical: 10,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: '#FEE2E2',
+    backgroundColor: '#FEF2F2',
+    alignItems: 'center',
+  },
+  cancelText: {
+    color: '#EF4444',
+    fontWeight: '600',
+    fontSize: 14,
+  },
+  emptyState: {
+    alignItems: 'center',
+    padding: 40,
+  },
+  emptyIcon: {
+    fontSize: 48,
+    marginBottom: 16,
+  },
+  emptyTitle: {
+    fontSize: 18,
+    fontWeight: '600',
+    color: '#111827',
+    marginBottom: 8,
+  },
+  emptyText: {
+    fontSize: 14,
+    color: '#6B7280',
+    textAlign: 'center',
+    marginBottom: 20,
+  },
+  emptyButton: {
+    backgroundColor: '#10B981',
+    paddingHorizontal: 24,
+    paddingVertical: 12,
+    borderRadius: 10,
+  },
+  emptyButtonText: {
+    color: '#fff',
+    fontWeight: '600',
+    fontSize: 16,
+  },
+  footer: {
+    padding: 16,
+    alignItems: 'center',
+    borderTopWidth: 1,
+    borderTopColor: '#E5E7EB',
+    backgroundColor: '#fff',
+  },
+  footerText: {
+    fontSize: 13,
+    color: '#6B7280',
+  },
+});

--- a/mobile/app/stock/[symbol].tsx
+++ b/mobile/app/stock/[symbol].tsx
@@ -1,0 +1,598 @@
+import { useState, useEffect } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  TouchableOpacity,
+  TextInput,
+  ActivityIndicator,
+  Alert,
+  KeyboardAvoidingView,
+  Platform,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useLocalSearchParams, router } from 'expo-router';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { tradingApi } from '../../src/api/trading';
+
+export default function StockDetailScreen() {
+  const { symbol } = useLocalSearchParams<{ symbol: string }>();
+  const queryClient = useQueryClient();
+  const [side, setSide] = useState<'buy' | 'sell'>('buy');
+  const [amount, setAmount] = useState('');
+  const [showOrderForm, setShowOrderForm] = useState(false);
+
+  // Fetch quote
+  const { data: quote, isLoading: quoteLoading, refetch: refetchQuote } = useQuery({
+    queryKey: ['quote', symbol],
+    queryFn: () => tradingApi.getQuote(symbol!),
+    enabled: !!symbol,
+    refetchInterval: 10000,
+  });
+
+  // Fetch asset details
+  const { data: asset } = useQuery({
+    queryKey: ['asset', symbol],
+    queryFn: () => tradingApi.getAsset(symbol!),
+    enabled: !!symbol,
+  });
+
+  // Fetch wallet balance
+  const { data: balance } = useQuery({
+    queryKey: ['walletBalance'],
+    queryFn: () => tradingApi.getWalletBalance(),
+  });
+
+  // Place order mutation
+  const placeOrderMutation = useMutation({
+    mutationFn: tradingApi.placeOrder,
+    onSuccess: (data) => {
+      Alert.alert(
+        'Order Placed',
+        `Your ${side} order for ${symbol} has been submitted.\n\nOrder ID: ${data.order_id}`,
+        [
+          {
+            text: 'View Orders',
+            onPress: () => router.push('/(tabs)/orders'),
+          },
+          {
+            text: 'OK',
+            style: 'cancel',
+          },
+        ]
+      );
+      setAmount('');
+      setShowOrderForm(false);
+      queryClient.invalidateQueries({ queryKey: ['walletBalance'] });
+      queryClient.invalidateQueries({ queryKey: ['orders'] });
+      queryClient.invalidateQueries({ queryKey: ['portfolio'] });
+    },
+    onError: (error: any) => {
+      Alert.alert(
+        'Order Failed',
+        error.response?.data?.message || error.message || 'Failed to place order'
+      );
+    },
+  });
+
+  const handlePlaceOrder = () => {
+    const amountNum = parseFloat(amount);
+    if (isNaN(amountNum) || amountNum <= 0) {
+      Alert.alert('Invalid Amount', 'Please enter a valid amount');
+      return;
+    }
+
+    if (side === 'buy' && balance && amountNum > balance.available) {
+      Alert.alert('Insufficient Funds', 'You do not have enough balance for this order');
+      return;
+    }
+
+    Alert.alert(
+      'Confirm Order',
+      `Are you sure you want to ${side} $${amountNum.toFixed(2)} of ${symbol}?`,
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Confirm',
+          onPress: () => {
+            placeOrderMutation.mutate({
+              symbol: symbol!,
+              side,
+              amount: amountNum,
+            });
+          },
+        },
+      ]
+    );
+  };
+
+  const quickAmounts = [50, 100, 250, 500, 1000];
+
+  const formatCurrency = (value: number) => {
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: 'USD',
+    }).format(value);
+  };
+
+  const estimatedShares = amount && quote ? parseFloat(amount) / quote.mid_price : 0;
+
+  if (!symbol) {
+    return (
+      <SafeAreaView style={styles.container}>
+        <Text>Invalid symbol</Text>
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <SafeAreaView style={styles.container} edges={['top']}>
+      <KeyboardAvoidingView
+        style={{ flex: 1 }}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      >
+        {/* Header */}
+        <View style={styles.header}>
+          <TouchableOpacity onPress={() => router.back()} style={styles.backButton}>
+            <Text style={styles.backText}>Back</Text>
+          </TouchableOpacity>
+          <View style={styles.headerTitle}>
+            <Text style={styles.symbol}>{symbol}</Text>
+            {asset && <Text style={styles.name}>{asset.name}</Text>}
+          </View>
+          <TouchableOpacity onPress={() => refetchQuote()} style={styles.refreshButton}>
+            <Text style={styles.refreshText}>Refresh</Text>
+          </TouchableOpacity>
+        </View>
+
+        <ScrollView style={styles.content}>
+          {/* Quote Card */}
+          <View style={styles.quoteCard}>
+            {quoteLoading ? (
+              <ActivityIndicator size="large" color="#10B981" />
+            ) : quote ? (
+              <>
+                <Text style={styles.price}>{formatCurrency(quote.mid_price)}</Text>
+                <View style={styles.quoteGrid}>
+                  <View style={styles.quoteItem}>
+                    <Text style={styles.quoteLabel}>Bid</Text>
+                    <Text style={styles.quoteValue}>{formatCurrency(quote.bid_price)}</Text>
+                  </View>
+                  <View style={styles.quoteItem}>
+                    <Text style={styles.quoteLabel}>Ask</Text>
+                    <Text style={styles.quoteValue}>{formatCurrency(quote.ask_price)}</Text>
+                  </View>
+                  <View style={styles.quoteItem}>
+                    <Text style={styles.quoteLabel}>Spread</Text>
+                    <Text style={styles.quoteValue}>{formatCurrency(quote.spread)}</Text>
+                  </View>
+                  <View style={styles.quoteItem}>
+                    <Text style={styles.quoteLabel}>Updated</Text>
+                    <Text style={styles.quoteValue}>
+                      {new Date(quote.timestamp).toLocaleTimeString()}
+                    </Text>
+                  </View>
+                </View>
+                {asset?.fractionable && (
+                  <View style={styles.fractionableTag}>
+                    <Text style={styles.fractionableText}>Fractional shares available</Text>
+                  </View>
+                )}
+              </>
+            ) : (
+              <Text style={styles.errorText}>Unable to load quote</Text>
+            )}
+          </View>
+
+          {/* Balance Card */}
+          <View style={styles.balanceCard}>
+            <Text style={styles.balanceLabel}>Available Balance</Text>
+            <Text style={styles.balanceValue}>
+              {balance ? formatCurrency(balance.available) : '---'}
+            </Text>
+          </View>
+
+          {/* Order Form */}
+          {showOrderForm ? (
+            <View style={styles.orderForm}>
+              <Text style={styles.orderTitle}>Place Order</Text>
+
+              {/* Buy/Sell Toggle */}
+              <View style={styles.sideToggle}>
+                <TouchableOpacity
+                  style={[styles.sideButton, side === 'buy' && styles.buyActive]}
+                  onPress={() => setSide('buy')}
+                >
+                  <Text style={[styles.sideText, side === 'buy' && styles.sideTextActive]}>
+                    Buy
+                  </Text>
+                </TouchableOpacity>
+                <TouchableOpacity
+                  style={[styles.sideButton, side === 'sell' && styles.sellActive]}
+                  onPress={() => setSide('sell')}
+                >
+                  <Text style={[styles.sideText, side === 'sell' && styles.sideTextActive]}>
+                    Sell
+                  </Text>
+                </TouchableOpacity>
+              </View>
+
+              {/* Amount Input */}
+              <View style={styles.inputContainer}>
+                <Text style={styles.inputLabel}>Amount (USD)</Text>
+                <View style={styles.inputWrapper}>
+                  <Text style={styles.currencySymbol}>$</Text>
+                  <TextInput
+                    style={styles.input}
+                    value={amount}
+                    onChangeText={setAmount}
+                    placeholder="0.00"
+                    placeholderTextColor="#9CA3AF"
+                    keyboardType="decimal-pad"
+                  />
+                </View>
+              </View>
+
+              {/* Quick Amounts */}
+              <View style={styles.quickAmounts}>
+                {quickAmounts.map((amt) => (
+                  <TouchableOpacity
+                    key={amt}
+                    style={styles.quickAmountButton}
+                    onPress={() => setAmount(amt.toString())}
+                  >
+                    <Text style={styles.quickAmountText}>${amt}</Text>
+                  </TouchableOpacity>
+                ))}
+              </View>
+
+              {/* Order Preview */}
+              {amount && parseFloat(amount) > 0 && quote && (
+                <View style={styles.orderPreview}>
+                  <View style={styles.previewRow}>
+                    <Text style={styles.previewLabel}>Estimated shares</Text>
+                    <Text style={styles.previewValue}>
+                      ~{estimatedShares.toFixed(6)} {symbol}
+                    </Text>
+                  </View>
+                  <View style={styles.previewRow}>
+                    <Text style={styles.previewLabel}>Price per share</Text>
+                    <Text style={styles.previewValue}>{formatCurrency(quote.mid_price)}</Text>
+                  </View>
+                  <View style={[styles.previewRow, styles.previewTotal]}>
+                    <Text style={styles.previewTotalLabel}>Total</Text>
+                    <Text style={styles.previewTotalValue}>
+                      {formatCurrency(parseFloat(amount))}
+                    </Text>
+                  </View>
+                </View>
+              )}
+
+              {/* Action Buttons */}
+              <View style={styles.actionButtons}>
+                <TouchableOpacity
+                  style={styles.cancelButton}
+                  onPress={() => {
+                    setShowOrderForm(false);
+                    setAmount('');
+                  }}
+                >
+                  <Text style={styles.cancelButtonText}>Cancel</Text>
+                </TouchableOpacity>
+                <TouchableOpacity
+                  style={[
+                    styles.submitButton,
+                    side === 'buy' ? styles.buyButton : styles.sellButton,
+                    (!amount || placeOrderMutation.isPending) && styles.submitButtonDisabled,
+                  ]}
+                  onPress={handlePlaceOrder}
+                  disabled={!amount || placeOrderMutation.isPending}
+                >
+                  {placeOrderMutation.isPending ? (
+                    <ActivityIndicator color="#fff" size="small" />
+                  ) : (
+                    <Text style={styles.submitButtonText}>
+                      {side === 'buy' ? 'Buy' : 'Sell'} {symbol}
+                    </Text>
+                  )}
+                </TouchableOpacity>
+              </View>
+            </View>
+          ) : (
+            /* Trade Button */
+            <TouchableOpacity
+              style={styles.tradeButton}
+              onPress={() => setShowOrderForm(true)}
+            >
+              <Text style={styles.tradeButtonText}>Trade {symbol}</Text>
+            </TouchableOpacity>
+          )}
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#F9FAFB',
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    padding: 16,
+    backgroundColor: '#fff',
+    borderBottomWidth: 1,
+    borderBottomColor: '#E5E7EB',
+  },
+  backButton: {
+    padding: 8,
+  },
+  backText: {
+    color: '#10B981',
+    fontSize: 16,
+    fontWeight: '500',
+  },
+  headerTitle: {
+    alignItems: 'center',
+  },
+  symbol: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: '#111827',
+  },
+  name: {
+    fontSize: 14,
+    color: '#6B7280',
+    marginTop: 2,
+  },
+  refreshButton: {
+    padding: 8,
+  },
+  refreshText: {
+    color: '#10B981',
+    fontSize: 14,
+  },
+  content: {
+    flex: 1,
+    padding: 16,
+  },
+  quoteCard: {
+    backgroundColor: '#fff',
+    borderRadius: 16,
+    padding: 24,
+    alignItems: 'center',
+    marginBottom: 16,
+  },
+  price: {
+    fontSize: 40,
+    fontWeight: 'bold',
+    color: '#111827',
+    marginBottom: 20,
+  },
+  quoteGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'space-between',
+    width: '100%',
+  },
+  quoteItem: {
+    width: '48%',
+    marginBottom: 12,
+  },
+  quoteLabel: {
+    fontSize: 13,
+    color: '#6B7280',
+    marginBottom: 4,
+  },
+  quoteValue: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#111827',
+  },
+  fractionableTag: {
+    backgroundColor: '#ECFDF5',
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 8,
+    marginTop: 16,
+  },
+  fractionableText: {
+    color: '#10B981',
+    fontSize: 13,
+    fontWeight: '500',
+  },
+  errorText: {
+    color: '#EF4444',
+    fontSize: 14,
+  },
+  balanceCard: {
+    backgroundColor: '#F3F4F6',
+    borderRadius: 12,
+    padding: 16,
+    marginBottom: 16,
+  },
+  balanceLabel: {
+    fontSize: 13,
+    color: '#6B7280',
+    marginBottom: 4,
+  },
+  balanceValue: {
+    fontSize: 24,
+    fontWeight: '700',
+    color: '#111827',
+  },
+  tradeButton: {
+    backgroundColor: '#10B981',
+    borderRadius: 12,
+    paddingVertical: 16,
+    alignItems: 'center',
+  },
+  tradeButtonText: {
+    color: '#fff',
+    fontSize: 18,
+    fontWeight: '600',
+  },
+  orderForm: {
+    backgroundColor: '#fff',
+    borderRadius: 16,
+    padding: 20,
+  },
+  orderTitle: {
+    fontSize: 18,
+    fontWeight: '600',
+    color: '#111827',
+    marginBottom: 16,
+  },
+  sideToggle: {
+    flexDirection: 'row',
+    backgroundColor: '#F3F4F6',
+    borderRadius: 10,
+    padding: 4,
+    marginBottom: 20,
+  },
+  sideButton: {
+    flex: 1,
+    paddingVertical: 12,
+    borderRadius: 8,
+    alignItems: 'center',
+  },
+  buyActive: {
+    backgroundColor: '#10B981',
+  },
+  sellActive: {
+    backgroundColor: '#EF4444',
+  },
+  sideText: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#6B7280',
+  },
+  sideTextActive: {
+    color: '#fff',
+  },
+  inputContainer: {
+    marginBottom: 16,
+  },
+  inputLabel: {
+    fontSize: 14,
+    fontWeight: '500',
+    color: '#374151',
+    marginBottom: 8,
+  },
+  inputWrapper: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#F9FAFB',
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: '#E5E7EB',
+    paddingHorizontal: 16,
+  },
+  currencySymbol: {
+    fontSize: 18,
+    color: '#6B7280',
+    marginRight: 4,
+  },
+  input: {
+    flex: 1,
+    fontSize: 18,
+    color: '#111827',
+    paddingVertical: 14,
+  },
+  quickAmounts: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+    marginBottom: 20,
+  },
+  quickAmountButton: {
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: '#E5E7EB',
+    backgroundColor: '#fff',
+  },
+  quickAmountText: {
+    fontSize: 14,
+    color: '#374151',
+    fontWeight: '500',
+  },
+  orderPreview: {
+    backgroundColor: '#F9FAFB',
+    borderRadius: 12,
+    padding: 16,
+    marginBottom: 20,
+  },
+  previewRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: 8,
+  },
+  previewLabel: {
+    fontSize: 14,
+    color: '#6B7280',
+  },
+  previewValue: {
+    fontSize: 14,
+    fontWeight: '500',
+    color: '#111827',
+  },
+  previewTotal: {
+    borderTopWidth: 1,
+    borderTopColor: '#E5E7EB',
+    paddingTop: 8,
+    marginTop: 4,
+  },
+  previewTotalLabel: {
+    fontSize: 15,
+    fontWeight: '600',
+    color: '#374151',
+  },
+  previewTotalValue: {
+    fontSize: 15,
+    fontWeight: '700',
+    color: '#111827',
+  },
+  actionButtons: {
+    flexDirection: 'row',
+    gap: 12,
+  },
+  cancelButton: {
+    flex: 1,
+    paddingVertical: 14,
+    borderRadius: 10,
+    alignItems: 'center',
+    borderWidth: 1,
+    borderColor: '#E5E7EB',
+  },
+  cancelButtonText: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#6B7280',
+  },
+  submitButton: {
+    flex: 2,
+    paddingVertical: 14,
+    borderRadius: 10,
+    alignItems: 'center',
+  },
+  buyButton: {
+    backgroundColor: '#10B981',
+  },
+  sellButton: {
+    backgroundColor: '#EF4444',
+  },
+  submitButtonDisabled: {
+    opacity: 0.5,
+  },
+  submitButtonText: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#fff',
+  },
+});

--- a/mobile/src/api/trading.ts
+++ b/mobile/src/api/trading.ts
@@ -1,0 +1,76 @@
+import apiClient from './client';
+import type {
+  DetailedQuote,
+  Asset,
+  Portfolio,
+  PlaceOrderRequest,
+  PlaceOrderResponse,
+  Order,
+  OrdersResponse,
+  AssetSearchResponse,
+  Wallet,
+} from '../types';
+
+// Asset search
+export async function searchAssets(query: string, limit = 20): Promise<AssetSearchResponse> {
+  return apiClient.get<AssetSearchResponse>('/trading/assets/search', { q: query, limit });
+}
+
+// Get quote for a symbol
+export async function getQuote(symbol: string): Promise<DetailedQuote> {
+  return apiClient.get<DetailedQuote>(`/trading/quotes/${symbol}`);
+}
+
+// Get asset details
+export async function getAsset(symbol: string): Promise<Asset> {
+  return apiClient.get<Asset>(`/trading/assets/${symbol}`);
+}
+
+// Get portfolio summary and holdings
+export async function getPortfolio(): Promise<Portfolio> {
+  return apiClient.get<Portfolio>('/portfolio');
+}
+
+// Get wallet balance
+export async function getWalletBalance(): Promise<Wallet> {
+  return apiClient.get<Wallet>('/wallet/balance');
+}
+
+// Place an order
+export async function placeOrder(request: PlaceOrderRequest): Promise<PlaceOrderResponse> {
+  return apiClient.post<PlaceOrderResponse>('/trading/orders', request);
+}
+
+// Get orders with optional status filter
+export async function getOrders(status?: string, limit = 50): Promise<OrdersResponse> {
+  const params: Record<string, any> = { limit };
+  if (status) {
+    params.status = status;
+  }
+  return apiClient.get<OrdersResponse>('/trading/orders', params);
+}
+
+// Get a single order by ID
+export async function getOrder(orderId: string): Promise<Order> {
+  return apiClient.get<Order>(`/trading/orders/${orderId}`);
+}
+
+// Cancel an order
+export async function cancelOrder(orderId: string): Promise<{ message: string }> {
+  return apiClient.delete<{ message: string }>(`/trading/orders/${orderId}`);
+}
+
+// Export all functions as a trading API object
+export const tradingApi = {
+  searchAssets,
+  getQuote,
+  getAsset,
+  getPortfolio,
+  getWalletBalance,
+  placeOrder,
+  getOrders,
+  getOrder,
+  cancelOrder,
+};
+
+export default tradingApi;

--- a/mobile/src/types/index.ts
+++ b/mobile/src/types/index.ts
@@ -120,6 +120,89 @@ export interface SearchResult {
   type: string;
 }
 
+// Extended Quote with bid/ask
+export interface DetailedQuote {
+  symbol: string;
+  bid_price: number;
+  bid_size: number;
+  ask_price: number;
+  ask_size: number;
+  mid_price: number;
+  spread: number;
+  timestamp: string;
+}
+
+// Asset from search
+export interface Asset {
+  id: string;
+  symbol: string;
+  name: string;
+  exchange: string;
+  class: string;
+  status: string;
+  tradable: boolean;
+  fractionable: boolean;
+}
+
+// Portfolio types
+export interface PortfolioSummary {
+  total_value: number;
+  total_cost_basis: number;
+  total_unrealized_pl: number;
+  total_unrealized_pl_pct: number;
+  day_change: number;
+  day_change_pct: number;
+  cash_balance: number;
+  holdings_count: number;
+}
+
+export interface PortfolioHolding {
+  symbol: string;
+  quantity: number;
+  avg_cost_basis: number;
+  total_cost_basis: number;
+  current_price: number;
+  market_value: number;
+  unrealized_pl: number;
+  unrealized_pl_pct: number;
+  day_change: number;
+  day_change_pct: number;
+  allocation_pct: number;
+}
+
+export interface Portfolio {
+  summary: PortfolioSummary;
+  holdings: PortfolioHolding[];
+}
+
+// Order response types
+export interface PlaceOrderRequest {
+  symbol: string;
+  side: 'buy' | 'sell';
+  amount?: number;
+  qty?: number;
+}
+
+export interface PlaceOrderResponse {
+  order_id: string;
+  alpaca_order_id: string;
+  symbol: string;
+  side: string;
+  amount: number;
+  status: string;
+  message: string;
+}
+
+export interface OrdersResponse {
+  orders: Order[];
+  count: number;
+}
+
+export interface AssetSearchResponse {
+  assets: Asset[];
+  total: number;
+}
+
 // API response wrapper
 export interface ApiResponse<T> {
   data?: T;


### PR DESCRIPTION
## Summary
- Add trading API module for mobile app
- Create stock detail screen with real-time quotes and buy/sell form  
- Create orders screen with status filtering and order cancellation
- Add orders tab to bottom navigation
- Update portfolio to use new Portfolio API with summary data
- Update trade screen to use asset search API

## Changes
- `mobile/src/api/trading.ts` - New trading API module
- `mobile/app/stock/[symbol].tsx` - Stock detail with quote and order form
- `mobile/app/(tabs)/orders.tsx` - Orders list with cancel functionality
- `mobile/app/(tabs)/_layout.tsx` - Add orders tab
- `mobile/app/(tabs)/portfolio.tsx` - Use Portfolio API with summary
- `mobile/app/(tabs)/trade.tsx` - Use asset search API
- `mobile/src/types/index.ts` - Add trading types

## Test Plan
- [ ] Search for stocks in trade screen
- [ ] Navigate to stock detail screen
- [ ] View real-time quote data
- [ ] Place buy/sell orders
- [ ] View orders in orders tab
- [ ] Filter orders by status
- [ ] Cancel pending orders
- [ ] View portfolio with holdings and P&L

Closes #95